### PR TITLE
feat: Implement tool filtering with allow/block modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,11 @@ The server is configured using a JSON file. Below is an example configuration:
         "logEnabled": false,
         "authTokens": [
           "SpecificTokens"
-        ]
+        ],
+        "toolFilter": {
+          "mode": "block", // "allow" or "block" (default: "block")
+          "list": ["tool_name_to_block_or_allow"]
+        }
       }
     },
     "amap": {
@@ -93,8 +97,13 @@ Common options for `mcpProxy` and `mcpServers`.
 - `panicIfInvalid`: If true, the server will panic if the client is invalid.
 - `logEnabled`: If true, the server will log the client's requests.
 - `authTokens`: A list of authentication tokens for the client. The `Authorization` header will be checked against this list. 
+- `toolFilter`: Optional tool filtering configuration.
+  - `mode`: "allow" or "block" (default: "block")
+  - `list`: A list of tool names to block or allow
 
-> In the new configuration, the `authTokens` of `mcpProxy` is not a global authentication token, but rather the default authentication token for `mcpProxy`. When `authTokens` is set in `mcpServers`, the value of `authTokens` in `mcpServers` will be used instead of the value in `mcpProxy`. In other words, the `authTokens` of `mcpProxy` serves as a default value and is only applied when `authTokens` is not set in `mcpServers`.
+  > **Tip:** If you don't know the exact tool names, run the proxy once without any `toolFilter` configured. The console will log messages like `<server_name> Adding tool <tool_name>` for each successfully registered tool. You can use these logged names in your `toolFilter` list.
+
+ > In the new configuration, the `authTokens` of `mcpProxy` is not a global authentication token, but rather the default authentication token for `mcpProxy`. When `authTokens` is set in `mcpServers`, the value of `authTokens` in `mcpServers` will be used instead of the value in `mcpProxy`. In other words, the `authTokens` of `mcpProxy` serves as a default value and is only applied when `authTokens` is not set in `mcpServers`.
 > Other fields are the same.
 
 ### **`mcpProxy`**

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The server is configured using a JSON file. Below is an example configuration:
           "SpecificTokens"
         ],
         "toolFilter": {
-          "mode": "block", // "allow" or "block" (default: "block")
+          "mode": "block", // Must be explicitly set to "allow" or "block"
           "list": ["tool_name_to_block_or_allow"]
         }
       }
@@ -98,8 +98,8 @@ Common options for `mcpProxy` and `mcpServers`.
 - `logEnabled`: If true, the server will log the client's requests.
 - `authTokens`: A list of authentication tokens for the client. The `Authorization` header will be checked against this list. 
 - `toolFilter`: Optional tool filtering configuration.
-  - `mode`: "allow" or "block" (default: "block")
-  - `list`: A list of tool names to block or allow
+  - `mode`: Specifies the filtering mode. Must be explicitly set to "allow" or "block" if `list` is provided. If `list` is present but `mode` is missing or invalid, the filter will be ignored for this server.
+  - `list`: A list of tool names to filter (either allow or block based on the `mode`).
 
   > **Tip:** If you don't know the exact tool names, run the proxy once without any `toolFilter` configured. The console will log messages like `<server_name> Adding tool <tool_name>` for each successfully registered tool. You can use these logged names in your `toolFilter` list.
 

--- a/config.go
+++ b/config.go
@@ -82,10 +82,16 @@ func parseMCPClientConfigV1(conf *MCPClientConfigV1) (any, error) {
 
 // ---- V2 ----
 
+type ToolFilterConfig struct {
+	Mode string   `json:"mode,omitempty"` // 过滤模式 ("allow" or "block")
+	List []string `json:"list,omitempty"` // 用于过滤的工具列表
+}
+
 type OptionsV2 struct {
 	PanicIfInvalid optional.Field[bool] `json:"panicIfInvalid,omitempty"`
 	LogEnabled     optional.Field[bool] `json:"logEnabled,omitempty"`
 	AuthTokens     []string             `json:"authTokens,omitempty"`
+	ToolFilter     *ToolFilterConfig    `json:"toolFilter,omitempty"` // 工具过滤配置
 }
 
 type MCPProxyConfigV2 struct {


### PR DESCRIPTION
# 实现基于允许/阻止模式的工具过滤功能

## 概述
本次提交为 MCP Proxy 引入了一项重要的增强功能：基于配置的工具过滤机制。用户现在可以在代理层面对每个后端 MCP 服务器暴露的工具进行精细化控制，支持"允许列表"（allowlist）和"阻止列表"（blocklist）两种模式。

## 主要动机与解决的问题
在实际使用中，用户可能会同时接入多个 MCP 服务器。这常常导致以下几个痛点：

- **功能重叠与选择困难**：不同的 MCP 服务器可能提供功能相似但实现质量或效果不同的工具（例如，多个网页搜索工具）。用户希望能够只保留并暴露其中最优的工具，避免混淆。
- **工具冗余与上下文膨胀**：某些 MCP 服务器可能捆绑了大量工具，但用户实际只需要其中少数几个核心工具。将所有工具信息传递给下游（尤其是 LLM）会显著增加上下文长度，不仅浪费 Token，也可能影响 LLM 的性能和决策效率。
- **LLM 决策负担**：过多的工具选项会增加 LLM 在选择合适工具时的复杂度和不确定性。精确地提供所需的工具集可以减轻 LLM 的负担。
- **客户端能力差异**：虽然现在有部分客户端具备工具过滤能力，但并非所有客户端都支持。在 MCP Proxy 这个代理源头提供统一的过滤能力，可以确保无论下游客户端能力如何，都能实现工具的按需暴露。

## 实现方案
我们在 `config.json` 中 `mcpServers` 数组内每个服务器配置的 `options` 对象下，新增了一个可选的 `toolFilter` 字段。其结构如下：

```json
"options": {
  // ... 其他选项 ...
  "toolFilter": {
    "mode": "allow", // 或 "block"，字符串，指定模式，默认为 "block"
    "list": ["tool_name_1", "tool_name_2"] // 字符串数组，包含要允许或阻止的工具名称
  }
}
```

- `mode: "allow"`：白名单模式，只有 `list` 中列出的工具会被代理暴露。
- `mode: "block"`：黑名单模式（默认），`list` 中列出的工具会被阻止，其他工具则被暴露。

如果 `toolFilter` 或其 `list` 字段不存在或为空，则该服务器的所有工具都会被暴露（无过滤）。

## 带来的价值
- **高度灵活性**：用户可以根据实际需求，自由"混搭"和组合来自不同 MCP 源的最佳工具集。
- **效率与成本优化**：通过精简工具列表，显著减少传递给 LLM 的上下文，节省 Token 成本，并可能提升 LLM 的响应速度和工具选择准确率。
- **源头控制与一致性**：在代理层提供过滤能力，保证了工具暴露的一致性，减轻了对特定客户端能力的依赖。

---

# Implement Tool Filtering with Allow/Block Modes

### Description
This commit introduces a significant enhancement to MCP Proxy: configuration-based tool filtering. Users can now exercise fine-grained control over the tools exposed by each backend MCP server at the proxy level, supporting both "allowlist" and "blocklist" modes.

### Motivation and Problems Solved
In practical usage, users might connect to multiple MCP servers simultaneously. This often leads to several pain points:

- **Tool Overlap & Selection Difficulty**: Different MCP servers may offer tools with similar functionality but varying implementation quality or effectiveness (e.g., multiple web search tools). Users often wish to expose only the best-performing tools to avoid confusion.
- **Tool Redundancy & Context Bloat**: Some MCP servers bundle numerous tools, while users might only need a few core ones. Passing information about all tools downstream (especially to LLMs) significantly increases context length, wasting tokens and potentially impacting LLM performance and decision-making efficiency.
- **LLM Decision Burden**: An excessive number of tool options increases the complexity and uncertainty for the LLM when selecting the appropriate tool. Providing a precise, curated set of tools can alleviate this burden.
- **Client Capability Discrepancies**: While some clients now possess tool filtering capabilities, many do not. Providing a unified filtering mechanism at the MCP Proxy source ensures consistent tool exposure regardless of downstream client capabilities.

### Implementation
We've added an optional `toolFilter` field within the `options` object for each server configuration under the `mcpServers` array in `config.json`. The structure is as follows:

```json
"options": {
  // ... other options ...
  "toolFilter": {
    "mode": "allow", // or "block" (string, specifies the mode, defaults to "block")
    "list": ["tool_name_1", "tool_name_2"] // string array, contains tool names to allow or block
  }
}
```

- `mode: "allow"`: Allowlist mode; only tools listed in `list` will be exposed by the proxy.
- `mode: "block"`: Blocklist mode (default); tools listed in `list` will be blocked, while all others are exposed.

If `toolFilter` or its `list` field is absent or empty, all tools from that server will be exposed (no filtering).

### Value Proposition
- **High Flexibility**: Users can freely "mix and match" the best tools from different MCP sources according to their needs.
- **Efficiency & Cost Optimization**: Significantly reduces the context passed to LLMs by trimming the tool list, saving token costs, and potentially improving LLM response speed and tool selection accuracy.
- **Source Control & Consistency**: Provides filtering at the proxy layer, ensuring consistent tool exposure and reducing reliance on specific client capabilities.