### PR TITLE
ci: automate tagged releases with GoReleaser and GitHub Actions

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,42 @@
+name: Goreleaser
+
+on:
+  push:
+    tags:
+      - "*"
+
+env:
+  GOPATH: /go_path
+  GOCACHE: /go_cache
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          check-latest: true
+          go-version: "^1"
+
+      - name: cache go
+        id: cache-go
+        uses: actions/cache@v4
+        with:
+          path: |
+            /go_path
+            /go_cache
+          key: go_path-${{ steps.hash-go.outputs.hash }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          args: release --clean
+        env:
+          GITEA_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,23 +33,24 @@ changelog:
   #
   # Default is no groups.
   groups:
+  groups:
     - title: Features
-      regexp: "^.*feat[(\\w-)]*:+.*$"
+      regexp: '^feat(\([\w-]+\))?!?:.*'
       order: 0
-    - title: "Bug fixes"
-      regexp: "^.*fix[(\\w-)]*:+.*$"
+    - title: "Bug Fixes"
+      regexp: '^fix(\([\w-]+\))?!?:.*'
       order: 1
-    - title: "Enhancements"
-      regexp: "^.*chore[(\\w-)]*:+.*$"
-      order: 2
     - title: "Refactor"
-      regexp: "^.*refactor[(\\w-)]*:+.*$"
+      regexp: '^refactor(\([\w-]+\))?!?:.*'
+      order: 2
+    - title: "Build Process Updates"
+      regexp: '^(build|ci)(\([\w-]+\))?!?:.*'
       order: 3
-    - title: "Build process updates"
-      regexp: ^.*?(build|ci)(\(.+\))??!?:.+$
+    - title: "Documentation Updates"
+      regexp: '^docs(\([\w-]+\))?!?:.*'
       order: 4
-    - title: "Documentation updates"
-      regexp: ^.*?docs?(\(.+\))??!?:.+$
-      order: 4
+    - title: "Maintenance"
+      regexp: '^chore(\([\w-]+\))?!?:.*'
+      order: 5
     - title: Others
       order: 999

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+builds:
+  - # If true, skip the build.
+    # Useful for library projects.
+    # Default is false
+    skip: true
+
+changelog:
+  # Set it to true if you wish to skip the changelog generation.
+  # This may result in an empty release notes on GitHub/GitLab/Gitea.
+  disable: false
+
+  # Changelog generation implementation to use.
+  #
+  # Valid options are:
+  # - `git`: uses `git log`;
+  # - `github`: uses the compare GitHub API, appending the author login to the changelog.
+  # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog.
+  # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
+  # - `gitea`: uses the compare Gitea API, appending the author login to the changelog.
+  #
+  # Defaults to `git`.
+  use: github
+
+  # Sorts the changelog by the commit's messages.
+  # Could either be asc, desc or empty
+  # Default is empty
+  sort: asc
+
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Proving no regex means all commits will be grouped under the default group.
+  # Groups are disabled when using github-native, as it already groups things by itself.
+  #
+  # Default is no groups.
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w-)]*:+.*$"
+      order: 0
+    - title: "Bug fixes"
+      regexp: "^.*fix[(\\w-)]*:+.*$"
+      order: 1
+    - title: "Enhancements"
+      regexp: "^.*chore[(\\w-)]*:+.*$"
+      order: 2
+    - title: "Refactor"
+      regexp: "^.*refactor[(\\w-)]*:+.*$"
+      order: 3
+    - title: "Build process updates"
+      regexp: ^.*?(build|ci)(\(.+\))??!?:.+$
+      order: 4
+    - title: "Documentation updates"
+      regexp: ^.*?docs?(\(.+\))??!?:.+$
+      order: 4
+    - title: Others
+      order: 999

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,14 @@
 builds:
-  - # If true, skip the build.
-    # Useful for library projects.
-    # Default is false
-    skip: true
+  - id: mcp-proxy
+    main: .
+    binary: mcp-proxy
+    ldflags:
+      - -s -w -X main.BuildVersion={{.Version}}
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
 
 changelog:
   # Set it to true if you wish to skip the changelog generation.


### PR DESCRIPTION
- Add a GitHub Actions workflow to automate releases using GoReleaser when tags are pushed
- Introduce a GoReleaser configuration file with build skipping, changelog grouping, and changelog sorting enabled