### PR TITLE
refactor: refactor HTTP transport to clone default with insecure option

### DIFF
--- a/config.go
+++ b/config.go
@@ -134,12 +134,9 @@ type FullConfig struct {
 func load(path string, insecure bool) (*Config, error) {
 	httpClient := http.DefaultClient
 	if insecure {
-		httpClient = &http.Client{
-			Transport: &http.Transport{
-				// Disable TLS verification for insecure connections
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			},
-		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		httpClient = &http.Client{Transport: transport}
 	}
 
 	conf, err := confstore.Load[FullConfig](


### PR DESCRIPTION
- Use a cloned default HTTP transport with InsecureSkipVerify instead of redefining the transport from scratch when insecure mode is enabled

Instead of creating a new http.Transport from scratch, consider cloning http.DefaultTransport to preserve its default settings (e.g., timeouts, keep-alives).