### PR TITLE
fix: HTTP headers not being sent on the request

### DIFF
--- a/config.go
+++ b/config.go
@@ -163,6 +163,9 @@ func newConfProvider(path string, insecure, expandEnv bool, httpHeaders string, 
 					}
 				}
 			}
+			if len(headers) > 0 {
+				opts = append(opts, http.WithHeaders(headers))
+			}
 		}
 		pro := http.New(path, opts...)
 		if expandEnv {


### PR DESCRIPTION
Fixes #45

## Changes
- Added http.WithHeaders(headers) option to HTTP provider when http-headers flag is specified
- Headers are now correctly forwarded when fetching remote configuration URLs