### PR TITLE
Build with patched Go toolchain

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -17,6 +17,8 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.2'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5 AS builder
+FROM golang:1.26.2 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tbxark/mcp-proxy
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/go-sphere/confstore v0.0.4


### PR DESCRIPTION
## Summary
- raise the module Go directive to 1.26.2
- pin the GoReleaser workflow to Go 1.26.2
- update the Docker builder image from `golang:1.25.5` to `golang:1.26.2`

## Why
`govulncheck ./...` reported reachable public Go standard-library vulnerabilities when scanning the current tree, including crypto/x509, crypto/tls, and net/url findings fixed in Go 1.26.1/1.26.2. Building with Go 1.26.2 removes those reachable findings.

## Verification
- `go test ./...`
- `$(go env GOPATH)/bin/govulncheck ./...` now reports 0 reachable vulnerabilities