### PR TITLE
docs: note Go version for source install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ make build
 
 ### Install via Go
 
+Requires Go 1.24+.
+
 ```bash
 go install github.com/tbxark/mcp-proxy@latest
 ```


### PR DESCRIPTION
## Summary
- note that the Go install path requires Go 1.24+
- align the README prerequisite with the current `go.mod` directive

## Safety
- docs-only README change
- no clone, dependency install, build, or untrusted code execution
