### PR TITLE
fix: drain stderr pipe to prevent deadlock on Windows

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -37,6 +38,9 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 		mcpClient, err := client.NewStdioMCPClient(v.Command, envs, v.Args...)
 		if err != nil {
 			return nil, err
+		}
+		if stdioTransport, ok := mcpClient.GetTransport().(*transport.Stdio); ok {
+			go io.Copy(io.Discard, stdioTransport.Stderr())
 		}
 
 		return &Client{

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -40,7 +41,22 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 			return nil, err
 		}
 		if stdioTransport, ok := mcpClient.GetTransport().(*transport.Stdio); ok {
-			go io.Copy(io.Discard, stdioTransport.Stderr())
+			if stderr := stdioTransport.Stderr(); stderr != nil {
+				go func() {
+					scanner := bufio.NewScanner(stderr)
+					for scanner.Scan() {
+						log.Printf("<%s:stderr> %s", name, scanner.Text())
+					}
+					if err := scanner.Err(); err != nil {
+						if errors.Is(err, bufio.ErrTooLong) {
+							log.Printf("<%s:stderr> line too long, falling back to discarding stderr", name)
+							_, _ = io.Copy(io.Discard, stderr)
+						} else {
+							log.Printf("<%s:stderr> error reading stderr: %v", name, err)
+						}
+					}
+				}()
+			}
 		}
 
 		return &Client{


### PR DESCRIPTION
**Fix: Drain stderr pipe to prevent deadlock on Windows**

When running `mcp-proxy` on Windows with an MCP server that writes large payloads to stderr, the proxy hangs after `"Successfully initialized MCP client"` and never lists tools.

**Root cause:** Windows pipe buffers are only 4KB. If the child process writes enough to stderr and nobody drains it, it blocks — taking stdout down with it. On Linux the buffer is 64KB so it rarely triggers.

**Fix:** Drain stderr asynchronously after `Start()` so the child never blocks.