### PR TITLE
feat: auto-reconnect backends instead of 404ing forever when down

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
@@ -15,12 +16,27 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+const (
+	pingInterval        = 30 * time.Second
+	pingTimeout         = 10 * time.Second
+	connectTimeout      = 30 * time.Second
+	defaultReconnectGap = 15 * time.Second
+)
+
 type Client struct {
 	name            string
 	needPing        bool
 	needManualStart bool
-	client          *client.Client
 	options         *OptionsV2
+	clientConf      any // *StdioMCPClientConfig | *SSEMCPClientConfig | *StreamableMCPClientConfig
+
+	mu     sync.Mutex
+	client *client.Client
+
+	// remembered so the ping task can re-establish a dropped backend on its own.
+	clientInfo  mcp.Implementation
+	mcpServer   *server.MCPServer
+	pingStarted bool
 }
 
 func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
@@ -28,38 +44,40 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 	if pErr != nil {
 		return nil, pErr
 	}
-	switch v := clientInfo.(type) {
+	c := &Client{
+		name:       name,
+		options:    conf.Options,
+		clientConf: clientInfo,
+	}
+	switch clientInfo.(type) {
+	case *StdioMCPClientConfig:
+		// stdio backends are spawned by the client constructor (no manual Start),
+		// but still ping them so a crashed subprocess is detected and respawned.
+		c.needPing = true
+	case *SSEMCPClientConfig, *StreamableMCPClientConfig:
+		c.needPing = true
+		c.needManualStart = true
+	}
+	return c, nil
+}
+
+// buildRawClient creates a fresh underlying transport client from the stored
+// config. Called on the first connect and again on every reconnect, so a dead
+// backend (closed Obsidian, crashed stdio server) is replaced rather than reused.
+func (c *Client) buildRawClient() (*client.Client, error) {
+	switch v := c.clientConf.(type) {
 	case *StdioMCPClientConfig:
 		envs := make([]string, 0, len(v.Env))
 		for kk, vv := range v.Env {
 			envs = append(envs, fmt.Sprintf("%s=%s", kk, vv))
 		}
-		mcpClient, err := client.NewStdioMCPClient(v.Command, envs, v.Args...)
-		if err != nil {
-			return nil, err
-		}
-
-		return &Client{
-			name:    name,
-			client:  mcpClient,
-			options: conf.Options,
-		}, nil
+		return client.NewStdioMCPClient(v.Command, envs, v.Args...)
 	case *SSEMCPClientConfig:
 		var options []transport.ClientOption
 		if len(v.Headers) > 0 {
 			options = append(options, client.WithHeaders(v.Headers))
 		}
-		mcpClient, err := client.NewSSEMCPClient(v.URL, options...)
-		if err != nil {
-			return nil, err
-		}
-		return &Client{
-			name:            name,
-			needPing:        true,
-			needManualStart: true,
-			client:          mcpClient,
-			options:         conf.Options,
-		}, nil
+		return client.NewSSEMCPClient(v.URL, options...)
 	case *StreamableMCPClientConfig:
 		var options []transport.StreamableHTTPCOption
 		if len(v.Headers) > 0 {
@@ -68,28 +86,37 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 		if v.Timeout > 0 {
 			options = append(options, transport.WithHTTPTimeout(v.Timeout))
 		}
-		mcpClient, err := client.NewStreamableHttpClient(v.URL, options...)
-		if err != nil {
-			return nil, err
-		}
-		return &Client{
-			name:            name,
-			needPing:        true,
-			needManualStart: true,
-			client:          mcpClient,
-			options:         conf.Options,
-		}, nil
+		return client.NewStreamableHttpClient(v.URL, options...)
 	}
 	return nil, errors.New("invalid client type")
 }
 
-func (c *Client) addToMCPServer(ctx context.Context, clientInfo mcp.Implementation, mcpServer *server.MCPServer) error {
+func (c *Client) getClient() *client.Client {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.client
+}
+
+// establish builds a fresh client, initializes it, atomically swaps it in
+// (closing the old one), then (re)registers tools/prompts/resources. Tool
+// handlers resolve the live client via getClient at call time, so swapping the
+// underlying connection is transparent to in-flight and future requests.
+func (c *Client) establish(ctx context.Context, clientInfo mcp.Implementation, mcpServer *server.MCPServer) error {
+	raw, err := c.buildRawClient()
+	if err != nil {
+		return err
+	}
+
+	startCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+
 	if c.needManualStart {
-		err := c.client.Start(ctx)
-		if err != nil {
-			return err
+		if sErr := raw.Start(startCtx); sErr != nil {
+			_ = raw.Close()
+			return sErr
 		}
 	}
+
 	initRequest := mcp.InitializeRequest{}
 	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	initRequest.Params.ClientInfo = clientInfo
@@ -98,31 +125,56 @@ func (c *Client) addToMCPServer(ctx context.Context, clientInfo mcp.Implementati
 		Roots:        nil,
 		Sampling:     nil,
 	}
-	_, err := c.client.Initialize(ctx, initRequest)
-	if err != nil {
-		return err
+	if _, iErr := raw.Initialize(startCtx, initRequest); iErr != nil {
+		_ = raw.Close()
+		return iErr
 	}
+
+	c.mu.Lock()
+	old := c.client
+	c.client = raw
+	c.mu.Unlock()
+	if old != nil {
+		_ = old.Close()
+	}
+
 	log.Printf("<%s> Successfully initialized MCP client", c.name)
 
-	err = c.addToolsToServer(ctx, mcpServer)
-	if err != nil {
+	if err = c.addToolsToServer(ctx, mcpServer); err != nil {
 		return err
 	}
 	_ = c.addPromptsToServer(ctx, mcpServer)
 	_ = c.addResourcesToServer(ctx, mcpServer)
 	_ = c.addResourceTemplatesToServer(ctx, mcpServer)
+	return nil
+}
 
-	if c.needPing {
+func (c *Client) addToMCPServer(ctx context.Context, clientInfo mcp.Implementation, mcpServer *server.MCPServer) error {
+	c.clientInfo = clientInfo
+	c.mcpServer = mcpServer
+
+	if err := c.establish(ctx, clientInfo, mcpServer); err != nil {
+		return err
+	}
+
+	if c.needPing && !c.pingStarted {
+		c.pingStarted = true
 		go c.startPingTask(ctx)
 	}
 	return nil
 }
 
+// reconnect rebuilds a dropped backend using the details remembered at first
+// connect. Safe to call repeatedly from the ping task.
+func (c *Client) reconnect(ctx context.Context) error {
+	return c.establish(ctx, c.clientInfo, c.mcpServer)
+}
+
 func (c *Client) startPingTask(ctx context.Context) {
-	interval := 30 * time.Second
-	ticker := time.NewTicker(interval)
+	ticker := time.NewTicker(pingInterval)
 	defer ticker.Stop()
 
+	autoReconnect := c.options.AutoReconnect.OrElse(true)
 	failCount := 0
 	for {
 		select {
@@ -130,14 +182,30 @@ func (c *Client) startPingTask(ctx context.Context) {
 			log.Printf("<%s> Context done, stopping ping", c.name)
 			return
 		case <-ticker.C:
-			if err := c.client.Ping(ctx); err != nil {
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return
+			pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+			err := c.getClient().Ping(pingCtx)
+			cancel()
+			if err == nil {
+				if failCount > 0 {
+					log.Printf("<%s> MCP Ping recovered after %d failures", c.name, failCount)
+					failCount = 0
 				}
-				failCount++
-				log.Printf("<%s> MCP Ping failed: %v (count=%d)", c.name, err, failCount)
-			} else if failCount > 0 {
-				log.Printf("<%s> MCP Ping recovered after %d failures", c.name, failCount)
+				continue
+			}
+			// Only the parent context being cancelled means we should stop; a
+			// per-ping timeout just signals an unhealthy backend to recover.
+			if ctx.Err() != nil {
+				return
+			}
+			failCount++
+			log.Printf("<%s> MCP Ping failed: %v (count=%d)", c.name, err, failCount)
+			if !autoReconnect {
+				continue
+			}
+			if rErr := c.reconnect(ctx); rErr != nil {
+				log.Printf("<%s> Reconnect failed: %v", c.name, rErr)
+			} else {
+				log.Printf("<%s> Reconnected after %d ping failure(s)", c.name, failCount)
 				failCount = 0
 			}
 		}
@@ -145,6 +213,7 @@ func (c *Client) startPingTask(ctx context.Context) {
 }
 
 func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServer) error {
+	cl := c.getClient()
 	toolsRequest := mcp.ListToolsRequest{}
 	filterFunc := func(toolName string) bool {
 		return true
@@ -179,7 +248,7 @@ func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServ
 	}
 
 	for {
-		tools, err := c.client.ListTools(ctx, toolsRequest)
+		tools, err := cl.ListTools(ctx, toolsRequest)
 		if err != nil {
 			return err
 		}
@@ -193,7 +262,9 @@ func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServ
 		for _, tool := range tools.Tools {
 			if filterFunc(tool.Name) {
 				log.Printf("<%s> Adding tool %s", c.name, tool.Name)
-				mcpServer.AddTool(tool, c.client.CallTool)
+				mcpServer.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return c.getClient().CallTool(ctx, request)
+				})
 			}
 		}
 		if tools.NextCursor == "" {
@@ -206,9 +277,10 @@ func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServ
 }
 
 func (c *Client) addPromptsToServer(ctx context.Context, mcpServer *server.MCPServer) error {
+	cl := c.getClient()
 	promptsRequest := mcp.ListPromptsRequest{}
 	for {
-		prompts, err := c.client.ListPrompts(ctx, promptsRequest)
+		prompts, err := cl.ListPrompts(ctx, promptsRequest)
 		if err != nil {
 			return err
 		}
@@ -221,7 +293,9 @@ func (c *Client) addPromptsToServer(ctx context.Context, mcpServer *server.MCPSe
 		log.Printf("<%s> Successfully listed %d prompts", c.name, len(prompts.Prompts))
 		for _, prompt := range prompts.Prompts {
 			log.Printf("<%s> Adding prompt %s", c.name, prompt.Name)
-			mcpServer.AddPrompt(prompt, c.client.GetPrompt)
+			mcpServer.AddPrompt(prompt, func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+				return c.getClient().GetPrompt(ctx, request)
+			})
 		}
 		if prompts.NextCursor == "" {
 			break
@@ -232,9 +306,10 @@ func (c *Client) addPromptsToServer(ctx context.Context, mcpServer *server.MCPSe
 }
 
 func (c *Client) addResourcesToServer(ctx context.Context, mcpServer *server.MCPServer) error {
+	cl := c.getClient()
 	resourcesRequest := mcp.ListResourcesRequest{}
 	for {
-		resources, err := c.client.ListResources(ctx, resourcesRequest)
+		resources, err := cl.ListResources(ctx, resourcesRequest)
 		if err != nil {
 			return err
 		}
@@ -248,7 +323,7 @@ func (c *Client) addResourcesToServer(ctx context.Context, mcpServer *server.MCP
 		for _, resource := range resources.Resources {
 			log.Printf("<%s> Adding resource %s", c.name, resource.Name)
 			mcpServer.AddResource(resource, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-				readResource, e := c.client.ReadResource(ctx, request)
+				readResource, e := c.getClient().ReadResource(ctx, request)
 				if e != nil {
 					return nil, e
 				}
@@ -265,9 +340,10 @@ func (c *Client) addResourcesToServer(ctx context.Context, mcpServer *server.MCP
 }
 
 func (c *Client) addResourceTemplatesToServer(ctx context.Context, mcpServer *server.MCPServer) error {
+	cl := c.getClient()
 	resourceTemplatesRequest := mcp.ListResourceTemplatesRequest{}
 	for {
-		resourceTemplates, err := c.client.ListResourceTemplates(ctx, resourceTemplatesRequest)
+		resourceTemplates, err := cl.ListResourceTemplates(ctx, resourceTemplatesRequest)
 		if err != nil {
 			return err
 		}
@@ -278,7 +354,7 @@ func (c *Client) addResourceTemplatesToServer(ctx context.Context, mcpServer *se
 		for _, resourceTemplate := range resourceTemplates.ResourceTemplates {
 			log.Printf("<%s> Adding resource template %s", c.name, resourceTemplate.Name)
 			mcpServer.AddResourceTemplate(resourceTemplate, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-				readResource, e := c.client.ReadResource(ctx, request)
+				readResource, e := c.getClient().ReadResource(ctx, request)
 				if e != nil {
 					return nil, e
 				}
@@ -294,8 +370,11 @@ func (c *Client) addResourceTemplatesToServer(ctx context.Context, mcpServer *se
 }
 
 func (c *Client) Close() error {
-	if c.client != nil {
-		return c.client.Close()
+	c.mu.Lock()
+	cl := c.client
+	c.mu.Unlock()
+	if cl != nil {
+		return cl.Close()
 	}
 	return nil
 }
@@ -348,4 +427,40 @@ func newMCPServer(name string, serverConfig *MCPProxyConfigV2, clientConfig *MCP
 	}
 
 	return srv, nil
+}
+
+// connectWithRetry brings a backend online in the background. The HTTP route is
+// already registered by the caller, so the endpoint exists immediately; this
+// just keeps trying to populate it until the backend is reachable. Once
+// connected, ongoing liveness/recovery is handled by the ping task.
+func connectWithRetry(ctx context.Context, c *Client, info mcp.Implementation, mcpServer *server.MCPServer, opts *OptionsV2) {
+	gap := opts.ReconnectInterval
+	if gap <= 0 {
+		gap = defaultReconnectGap
+	}
+	autoReconnect := opts.AutoReconnect.OrElse(true)
+
+	attempt := 0
+	for {
+		attempt++
+		log.Printf("<%s> Connecting (attempt %d)", c.name, attempt)
+		err := c.addToMCPServer(ctx, info, mcpServer)
+		if err == nil {
+			log.Printf("<%s> Connected", c.name)
+			return
+		}
+		log.Printf("<%s> Failed to connect: %v", c.name, err)
+		if opts.PanicIfInvalid.OrElse(false) {
+			log.Fatalf("<%s> Failed to add client to server: %v", c.name, err)
+		}
+		if !autoReconnect {
+			log.Printf("<%s> Auto-reconnect disabled, giving up on this backend", c.name)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(gap):
+		}
+	}
 }

--- a/config.go
+++ b/config.go
@@ -67,6 +67,13 @@ type OptionsV2 struct {
 	AuthTokens     []string             `json:"authTokens,omitempty"`
 	ToolFilter     *ToolFilterConfig    `json:"toolFilter,omitempty"`
 	Disabled       bool                 `json:"disabled,omitempty"`
+	// AutoReconnect (default true) keeps retrying a backend that is unreachable
+	// at startup and re-establishes one that drops later, instead of leaving the
+	// route permanently broken. Set to false to restore fail-once behaviour.
+	AutoReconnect optional.Field[bool] `json:"autoReconnect"`
+	// ReconnectInterval is the gap between connection attempts while a backend is
+	// unreachable at startup. Defaults to 15s when unset.
+	ReconnectInterval time.Duration `json:"reconnectInterval,omitempty"`
 }
 
 type MCPProxyConfigV2 struct {
@@ -213,6 +220,12 @@ func load(path string, insecure, expandEnv bool, httpHeaders string, httpTimeout
 		}
 		if !clientConfig.Options.LogEnabled.Present() {
 			clientConfig.Options.LogEnabled = conf.McpProxy.Options.LogEnabled
+		}
+		if !clientConfig.Options.AutoReconnect.Present() {
+			clientConfig.Options.AutoReconnect = conf.McpProxy.Options.AutoReconnect
+		}
+		if clientConfig.Options.ReconnectInterval <= 0 {
+			clientConfig.Options.ReconnectInterval = conf.McpProxy.Options.ReconnectInterval
 		}
 	}
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,9 +86,12 @@ Common fields:
   - `mode`: `allow` or `block`.
   - `list`: List of tool names.
 - `Disabled` (bool): Enable or disable this server. Disabled servers are skipped at startup.
+- `autoReconnect` (bool, default `true`): Keep retrying a backend that is unreachable at startup, and re-establish one that drops later (detected via the ping task). The HTTP route is registered immediately regardless, so the endpoint never 404s just because the backend was down at the time the proxy started. Set to `false` to restore the previous fail-once behaviour. Ignored when `panicIfInvalid` is true.
+- `reconnectInterval` (duration in ns, default `15s`): Gap between connection attempts while a backend is unreachable at startup.
 
 Notes:
 
 - `mcpProxy.options.authTokens` serves as the default token set if a server omits `options.authTokens`.
+- `mcpProxy.options.autoReconnect` / `reconnectInterval` serve as defaults for servers that omit them.
 - To discover tool names for filtering, start without a filter and check logs for lines like `<server> Adding tool <name>`.
 

--- a/http.go
+++ b/http.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"golang.org/x/sync/errgroup"
 )
 
 type MiddlewareFunc func(http.Handler) http.Handler
@@ -82,7 +81,6 @@ func startHTTPServer(config *Config) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var errorGroup errgroup.Group
 	httpMux := http.NewServeMux()
 	httpServer := &http.Server{
 		Addr:    config.McpProxy.Addr,
@@ -105,50 +103,38 @@ func startHTTPServer(config *Config) error {
 		if err != nil {
 			return err
 		}
-		errorGroup.Go(func() error {
-			log.Printf("<%s> Connecting", name)
-			addErr := mcpClient.addToMCPServer(ctx, info, server.mcpServer)
-			if addErr != nil {
-				log.Printf("<%s> Failed to add client to server: %v", name, addErr)
-				if clientConfig.Options.PanicIfInvalid.OrElse(false) {
-					return addErr
-				}
-				return nil
-			}
-			log.Printf("<%s> Connected", name)
 
-			middlewares := make([]MiddlewareFunc, 0)
-			middlewares = append(middlewares, recoverMiddleware(name))
-			if clientConfig.Options.LogEnabled.OrElse(false) {
-				middlewares = append(middlewares, loggerMiddleware(name))
-			}
-			if len(clientConfig.Options.AuthTokens) > 0 {
-				middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
-			}
-			mcpRoute := path.Join(baseURL.Path, name)
-			if !strings.HasPrefix(mcpRoute, "/") {
-				mcpRoute = "/" + mcpRoute
-			}
-			if !strings.HasSuffix(mcpRoute, "/") {
-				mcpRoute += "/"
-			}
-			log.Printf("<%s> Handling requests at %s", name, mcpRoute)
-			httpMux.Handle(mcpRoute, chainMiddleware(server.handler, middlewares...))
-			httpServer.RegisterOnShutdown(func() {
-				log.Printf("<%s> Shutting down", name)
-				_ = mcpClient.Close()
-			})
-			return nil
-		})
-	}
-
-	go func() {
-		err := errorGroup.Wait()
-		if err != nil {
-			log.Fatalf("Failed to add clients: %v", err)
+		// Register the route up-front so the endpoint exists even before the
+		// backend is reachable. The handler resolves the live client lazily, so
+		// tools become available once the connection succeeds and survive
+		// reconnects. This avoids the route never being registered (and the
+		// endpoint 404ing forever) when a backend is down at startup.
+		middlewares := make([]MiddlewareFunc, 0)
+		middlewares = append(middlewares, recoverMiddleware(name))
+		if clientConfig.Options.LogEnabled.OrElse(false) {
+			middlewares = append(middlewares, loggerMiddleware(name))
 		}
-		log.Printf("All clients initialized")
-	}()
+		if len(clientConfig.Options.AuthTokens) > 0 {
+			middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
+		}
+		mcpRoute := path.Join(baseURL.Path, name)
+		if !strings.HasPrefix(mcpRoute, "/") {
+			mcpRoute = "/" + mcpRoute
+		}
+		if !strings.HasSuffix(mcpRoute, "/") {
+			mcpRoute += "/"
+		}
+		log.Printf("<%s> Handling requests at %s", name, mcpRoute)
+		httpMux.Handle(mcpRoute, chainMiddleware(server.handler, middlewares...))
+
+		client := mcpClient
+		httpServer.RegisterOnShutdown(func() {
+			log.Printf("<%s> Shutting down", name)
+			_ = client.Close()
+		})
+
+		go connectWithRetry(ctx, mcpClient, info, server.mcpServer, clientConfig.Options)
+	}
 
 	go func() {
 		log.Printf("Starting %s server", config.McpProxy.Type)


### PR DESCRIPTION
## Problem

If a backend is unreachable when the proxy starts (and `panicIfInvalid` is `false`, the default), its route is **never registered** and the endpoint returns `404 page not found` *forever* — the only fix is restarting the whole proxy.

Root cause is in `startHTTPServer` (`http.go`): the route is registered *inside* the per-backend goroutine, only **after** `addToMCPServer` succeeds:

```go
errorGroup.Go(func() error {
    addErr := mcpClient.addToMCPServer(ctx, info, server.mcpServer)
    if addErr != nil {
        if panicIfInvalid { return addErr }
        return nil            // <- gives up; httpMux.Handle never runs
    }
    ...
    httpMux.Handle(mcpRoute, ...) // <- only reached on success
})
```

Two real-world cases this hurts:
1. **Down at startup, comes up later** — e.g. the proxy runs at login before an app that backs a `streamable-http` server is ready → route 404s permanently.
2. **Was up, then dropped** — the app/subprocess restarts; the existing ping task (`client.go`) detects the failure but only **logs** it, never reconnects.

I'd been working around both with an external watchdog that restarts the whole proxy on a timer; this fixes it in-process instead.

## Changes

- **Register the route up-front**, before connecting. The handler resolves the live client lazily via a mutex-guarded `getClient()`, so the endpoint exists immediately and tools populate once the backend is reachable.
- **Retry the initial connect** in the background (`connectWithRetry`) until it succeeds, instead of giving up after one attempt.
- **Reconnect on ping failure**: rebuild the underlying client, re-initialize, and re-register tools/prompts/resources, swapping it in atomically. Transparent to in-flight/future requests since handlers go through `getClient()`.
- **Enable ping for stdio backends** too, so a crashed subprocess is detected and respawned (stdio previously had no liveness check).
- Removed the now-unused `errgroup` usage.

## New options (per-server, inheritable from `mcpProxy.options`)

| Option | Type | Default | Meaning |
|---|---|---|---|
| `autoReconnect` | bool | `true` | Retry-at-startup + reconnect-on-drop. Set `false` to restore fail-once behaviour. |
| `reconnectInterval` | duration (ns) | `15s` | Gap between startup connection attempts. |

`panicIfInvalid` still fails fast and takes precedence over `autoReconnect`.

## Testing

Built and `go vet` clean. Verified end-to-end on Windows:

**Down at startup (case 1):** backend pointed at a closed port →
- `GET /deadbackend/mcp` returns **200** (route registered), not 404
- an unregistered route still 404s (control)
- logs show `Connecting (attempt N)` retrying at the configured interval

**Drop + recovery (case 2):** real `@modelcontextprotocol/server-everything` over stdio →
- connects, lists tools, serves traffic
- killed the server subprocess → `MCP Ping failed: transport closed (count=1)` → re-listed tools → `Reconnected after 1 ping failure(s)` within one ping cycle
- `tools/call echo` after reconnect returns `Echo: alive-after-reconnect` (new subprocess serving traffic)

## Compatibility

Default behaviour change: backends now self-heal by default rather than failing once. Set `autoReconnect: false` to opt out. `panicIfInvalid: true` is unaffected.