### PR TITLE
feat: add config validation mode

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,9 +8,25 @@
 -http-headers string   optional headers for config URL: 'Key1:Value1;Key2:Value2'
 -http-timeout int      timeout (seconds) for remote config fetch (default 10)
 -insecure              skip TLS verification for remote config
+-check-config          load and validate the config, then exit without starting the server
 -version               print version and exit
 -help                  print help and exit
 ```
+
+### Validating config
+
+Use `-check-config` to load and validate the configured config (local file or
+remote URL, exactly as normal startup does) without binding the HTTP server. On
+success it prints the number of configured MCP servers and exits `0`; on an
+invalid config it prints an error and exits non-zero.
+
+```bash
+mcp-proxy -config config.json -check-config
+# Config OK: 3 MCP server(s) configured
+```
+
+This is handy for CI, init containers, deployment scripts, and dashboards that
+want to validate a generated config before restarting a live proxy.
 
 ## Endpoints
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	expandEnv := flag.Bool("expand-env", true, "expand environment variables in config file")
 	httpHeaders := flag.String("http-headers", "", "optional HTTP headers for config URL, format: 'Key1:Value1;Key2:Value2'")
 	httpTimeout := flag.Int("http-timeout", 10, "HTTP timeout in seconds when fetching config from URL")
+	checkConfig := flag.Bool("check-config", false, "load and validate the config, then exit without starting the server")
 
 	version := flag.Bool("version", false, "print version and exit")
 	help := flag.Bool("help", false, "print help and exit")
@@ -29,6 +30,10 @@ func main() {
 	config, err := load(*conf, *insecure, *expandEnv, *httpHeaders, *httpTimeout)
 	if err != nil {
 		log.Fatalf("Failed to load config: %v", err)
+	}
+	if *checkConfig {
+		fmt.Printf("Config OK: %d MCP server(s) configured\n", len(config.McpServers))
+		return
 	}
 	err = startHTTPServer(config)
 	if err != nil {


### PR DESCRIPTION
## Summary
Adds a `-check-config` CLI flag that loads and validates the configured local or remote config, then exits without binding the HTTP server.

This is useful for CI, init containers, deployment scripts, and dashboards that want to validate generated mcp-proxy config before restarting a live proxy.

## Changes
- Add `-check-config` flag.
- Print a concise success message with configured MCP server count.
- Document the flag in `docs/USAGE.md`.

## Verification
- `go test ./...`
- `go run . -config config.json -check-config`