### PR TITLE
feat: add health check endpoints

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,6 +19,21 @@ Given `mcpProxy.baseURL = https://mcp.example.com` and a server key `fetch`:
 - For `type: sse`: `https://mcp.example.com/fetch/sse`
 - For `type: streamable-http`: `https://mcp.example.com/fetch/mcp`
 
+## Health checks
+
+Two unauthenticated endpoints are always served for liveness/readiness probes
+(Docker, reverse proxies, dashboards, monitoring):
+
+- `GET /_healthz` and `GET /_readyz` return `200` with a JSON status document.
+- `HEAD /_healthz` and `HEAD /_readyz` return `200` with an empty body.
+
+```bash
+curl http://127.0.0.1:9090/_healthz
+# {"name":"MCP Proxy","serverCount":3,"status":"ok","version":"1.0.0"}
+```
+
+These endpoints never require the proxy auth token.
+
 ## Auth
 
 If `options.authTokens` is set for a server, requests must include a bearer token:

--- a/http.go
+++ b/http.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -73,6 +74,37 @@ func recoverMiddleware(prefix string) MiddlewareFunc {
 	}
 }
 
+// healthHandler returns an unauthenticated handler for liveness/readiness
+// probes. It responds to GET with a small JSON status document and to HEAD with
+// an empty 200 body, so it can be used by Docker, reverse proxies, and
+// monitoring without speaking MCP or providing the proxy auth token.
+func healthHandler(config *Config) http.HandlerFunc {
+	type healthResponse struct {
+		Name        string `json:"name"`
+		ServerCount int    `json:"serverCount"`
+		Status      string `json:"status"`
+		Version     string `json:"version"`
+	}
+	body := healthResponse{
+		Name:        config.McpProxy.Name,
+		ServerCount: len(config.McpServers),
+		Status:      "ok",
+		Version:     config.McpProxy.Version,
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(body)
+		case http.MethodHead:
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		}
+	}
+}
+
 func startHTTPServer(config *Config) error {
 	baseURL, uErr := url.Parse(config.McpProxy.BaseURL)
 	if uErr != nil {
@@ -91,6 +123,11 @@ func startHTTPServer(config *Config) error {
 	info := mcp.Implementation{
 		Name: config.McpProxy.Name,
 	}
+
+	// Unauthenticated health endpoints for liveness/readiness probes.
+	health := healthHandler(config)
+	httpMux.HandleFunc("/_healthz", health)
+	httpMux.HandleFunc("/_readyz", health)
 
 	for name, clientConfig := range config.McpServers {
 		if clientConfig.Options.Disabled {


### PR DESCRIPTION
## Summary
Adds unauthenticated health check endpoints for deployments and monitoring:

- `GET /_healthz`
- `GET /_readyz`
- `HEAD /_healthz`
- `HEAD /_readyz`

The JSON response includes proxy name, version, status, and configured MCP server count.

## Why
mcp-proxy is often deployed behind Docker, reverse proxies, or dashboards that need a stable readiness/liveness URL without speaking MCP.

## Verification
- `go test ./...`
- Started a local proxy with a disabled dummy backend.
- `curl http://127.0.0.1:<port>/_healthz`
- `curl -I http://127.0.0.1:<port>/_readyz`