### PR TITLE
test: ensure resources/list returns empty JSON arrays

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -22,6 +22,34 @@ func TestMCPServerListResourcesReturnsEmptyArrayNotNull(t *testing.T) {
 		t.Fatalf("newMCPServer: %v", err)
 	}
 
+	assertEmptyJSONArray := func(t *testing.T, raw []byte, field, want string) {
+		t.Helper()
+
+		var decoded struct {
+			Error *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+			Result map[string]json.RawMessage `json:"result"`
+		}
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal response: %v\npayload: %s", err, string(raw))
+		}
+		if decoded.Error != nil {
+			t.Fatalf("unexpected JSON-RPC error (code %d): %s\nfull response: %s",
+				decoded.Error.Code, decoded.Error.Message, string(raw))
+		}
+
+		got, ok := decoded.Result[field]
+		if !ok {
+			t.Fatalf("response missing result.%s\nfull response: %s", field, string(raw))
+		}
+		if string(got) != want {
+			t.Fatalf("expected result.%s to be %s, got %s\nfull response: %s",
+				field, want, string(got), string(raw))
+		}
+	}
+
 	t.Run("resources/list", func(t *testing.T) {
 		resp := server.mcpServer.HandleMessage(context.Background(), []byte(`{
 			"jsonrpc": "2.0",
@@ -34,18 +62,7 @@ func TestMCPServerListResourcesReturnsEmptyArrayNotNull(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal response: %v", err)
 		}
-
-		var decoded struct {
-			Result struct {
-				Resources json.RawMessage `json:"resources"`
-			} `json:"result"`
-		}
-		if err := json.Unmarshal(raw, &decoded); err != nil {
-			t.Fatalf("unmarshal response: %v\npayload: %s", err, string(raw))
-		}
-		if string(decoded.Result.Resources) != "[]" {
-			t.Fatalf("expected resources to be [], got %s", string(decoded.Result.Resources))
-		}
+		assertEmptyJSONArray(t, raw, "resources", "[]")
 	})
 
 	t.Run("resources/templates/list", func(t *testing.T) {
@@ -60,17 +77,6 @@ func TestMCPServerListResourcesReturnsEmptyArrayNotNull(t *testing.T) {
 		if err != nil {
 			t.Fatalf("marshal response: %v", err)
 		}
-
-		var decoded struct {
-			Result struct {
-				ResourceTemplates json.RawMessage `json:"resourceTemplates"`
-			} `json:"result"`
-		}
-		if err := json.Unmarshal(raw, &decoded); err != nil {
-			t.Fatalf("unmarshal response: %v\npayload: %s", err, string(raw))
-		}
-		if string(decoded.Result.ResourceTemplates) != "[]" {
-			t.Fatalf("expected resourceTemplates to be [], got %s", string(decoded.Result.ResourceTemplates))
-		}
+		assertEmptyJSONArray(t, raw, "resourceTemplates", "[]")
 	})
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// Regression for https://github.com/tbxark/mcp-proxy/issues/66 — JetBrains MCP
+// clients reject null resource lists; empty collections must serialize as [].
+func TestMCPServerListResourcesReturnsEmptyArrayNotNull(t *testing.T) {
+	t.Parallel()
+
+	server, err := newMCPServer("test", &MCPProxyConfigV2{
+		Type:    MCPServerTypeStreamable,
+		Version: "test",
+		BaseURL: "http://localhost:9090",
+	}, &MCPClientConfigV2{
+		Options: &OptionsV2{},
+	})
+	if err != nil {
+		t.Fatalf("newMCPServer: %v", err)
+	}
+
+	t.Run("resources/list", func(t *testing.T) {
+		resp := server.mcpServer.HandleMessage(context.Background(), []byte(`{
+			"jsonrpc": "2.0",
+			"id": 1,
+			"method": "resources/list",
+			"params": {}
+		}`))
+
+		raw, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+
+		var decoded struct {
+			Result struct {
+				Resources json.RawMessage `json:"resources"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal response: %v\npayload: %s", err, string(raw))
+		}
+		if string(decoded.Result.Resources) != "[]" {
+			t.Fatalf("expected resources to be [], got %s", string(decoded.Result.Resources))
+		}
+	})
+
+	t.Run("resources/templates/list", func(t *testing.T) {
+		resp := server.mcpServer.HandleMessage(context.Background(), []byte(`{
+			"jsonrpc": "2.0",
+			"id": 2,
+			"method": "resources/templates/list",
+			"params": {}
+		}`))
+
+		raw, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal response: %v", err)
+		}
+
+		var decoded struct {
+			Result struct {
+				ResourceTemplates json.RawMessage `json:"resourceTemplates"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(raw, &decoded); err != nil {
+			t.Fatalf("unmarshal response: %v\npayload: %s", err, string(raw))
+		}
+		if string(decoded.Result.ResourceTemplates) != "[]" {
+			t.Fatalf("expected resourceTemplates to be [], got %s", string(decoded.Result.ResourceTemplates))
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Add regression tests so `resources/list` and `resources/templates/list` serialize empty collections as JSON arrays (`[]`) rather than `null`.

Fixes #66

## Motivation

JetBrains Copilot and other strict MCP clients break when list endpoints return `null` instead of an empty array. Issue #66 reported this for resource listings.

Current `master` already returns `[]` via `mcp-go` v0.44.0; this PR locks that wire-format contract in place.

## Changes

- Add `client_test.go` with `TestMCPServerListResourcesReturnsEmptyArrayNotNull`
- Exercise the real `newMCPServer` → `HandleMessage` path for streamable HTTP servers
- Assert raw JSON for both `resources` and `resourceTemplates` fields is `[]`

## Tests

```bash
go test ./... -count=1
```

Result: PASS

## Notes

Regression coverage only — no runtime behavior change on current `master`.