### PR TITLE
fix(client): normalize toolFilter allow-list entries

### DIFF
--- a/client.go
+++ b/client.go
@@ -144,39 +144,52 @@ func (c *Client) startPingTask(ctx context.Context) {
 	}
 }
 
-func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServer) error {
-	toolsRequest := mcp.ListToolsRequest{}
+func buildToolFilterFunc(clientName string, options *OptionsV2) func(toolName string) bool {
 	filterFunc := func(toolName string) bool {
 		return true
 	}
-
-	if c.options != nil && c.options.ToolFilter != nil && len(c.options.ToolFilter.List) > 0 {
-		filterSet := make(map[string]struct{})
-		mode := ToolFilterMode(strings.ToLower(string(c.options.ToolFilter.Mode)))
-		for _, toolName := range c.options.ToolFilter.List {
-			filterSet[toolName] = struct{}{}
-		}
-		switch mode {
-		case ToolFilterModeAllow:
-			filterFunc = func(toolName string) bool {
-				_, inList := filterSet[toolName]
-				if !inList {
-					log.Printf("<%s> Ignoring tool %s as it is not in allow list", c.name, toolName)
-				}
-				return inList
-			}
-		case ToolFilterModeBlock:
-			filterFunc = func(toolName string) bool {
-				_, inList := filterSet[toolName]
-				if inList {
-					log.Printf("<%s> Ignoring tool %s as it is in block list", c.name, toolName)
-				}
-				return !inList
-			}
-		default:
-			log.Printf("<%s> Unknown tool filter mode: %s, skipping tool filter", c.name, mode)
-		}
+	if options == nil || options.ToolFilter == nil {
+		return filterFunc
 	}
+
+	filterList := normalizeToolFilterList(options.ToolFilter.List)
+	if len(filterList) == 0 {
+		return filterFunc
+	}
+
+	filterSet := make(map[string]struct{}, len(filterList))
+	mode := ToolFilterMode(strings.ToLower(string(options.ToolFilter.Mode)))
+	for _, toolName := range filterList {
+		filterSet[toolName] = struct{}{}
+	}
+	log.Printf("<%s> Applying toolFilter mode=%s for tools: %s", clientName, mode, strings.Join(filterList, ", "))
+
+	switch mode {
+	case ToolFilterModeAllow:
+		return func(toolName string) bool {
+			_, inList := filterSet[toolName]
+			if !inList {
+				log.Printf("<%s> Ignoring tool %s as it is not in allow list", clientName, toolName)
+			}
+			return inList
+		}
+	case ToolFilterModeBlock:
+		return func(toolName string) bool {
+			_, inList := filterSet[toolName]
+			if inList {
+				log.Printf("<%s> Ignoring tool %s as it is in block list", clientName, toolName)
+			}
+			return !inList
+		}
+	default:
+		log.Printf("<%s> Unknown tool filter mode: %s, skipping tool filter", clientName, mode)
+		return filterFunc
+	}
+}
+
+func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServer) error {
+	toolsRequest := mcp.ListToolsRequest{}
+	filterFunc := buildToolFilterFunc(c.name, c.options)
 
 	for {
 		tools, err := c.client.ListTools(ctx, toolsRequest)

--- a/config.go
+++ b/config.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"errors"
+	"fmt"
 	nethttp "net/http"
 	"strings"
 	"time"
@@ -59,6 +61,59 @@ const (
 type ToolFilterConfig struct {
 	Mode ToolFilterMode `json:"mode,omitempty"`
 	List []string       `json:"list,omitempty"`
+}
+
+// UnmarshalJSON accepts toolFilter.list as either a JSON array or a
+// comma-separated string. The latter is common when list values are injected
+// via environment-variable expansion (e.g. ENABLED_TOOLS="a,b,c").
+func (c *ToolFilterConfig) UnmarshalJSON(data []byte) error {
+	aux := struct {
+		Mode string          `json:"mode,omitempty"`
+		List json.RawMessage `json:"list,omitempty"`
+	}{}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	c.Mode = ToolFilterMode(strings.TrimSpace(string(aux.Mode)))
+	if len(aux.List) == 0 {
+		return nil
+	}
+	var list []string
+	if err := json.Unmarshal(aux.List, &list); err == nil {
+		c.List = list
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(aux.List, &single); err == nil {
+		c.List = []string{single}
+		return nil
+	}
+	return fmt.Errorf("toolFilter.list must be a string or array of strings")
+}
+
+// normalizeToolFilterList trims entries and expands comma-separated values so
+// env-expanded lists like ["a,b,c"] match individual tool names.
+func normalizeToolFilterList(list []string) []string {
+	seen := make(map[string]struct{}, len(list))
+	normalized := make([]string, 0, len(list))
+	for _, entry := range list {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		for part := range strings.SplitSeq(entry, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if _, exists := seen[part]; exists {
+				continue
+			}
+			seen[part] = struct{}{}
+			normalized = append(normalized, part)
+		}
+	}
+	return normalized
 }
 
 type OptionsV2 struct {

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestToolFilterConfigUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("array list", func(t *testing.T) {
+		var cfg ToolFilterConfig
+		if err := json.Unmarshal([]byte(`{
+			"mode": "allow",
+			"list": ["jira_get_issue", "jira_search"]
+		}`), &cfg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if cfg.Mode != ToolFilterModeAllow {
+			t.Fatalf("mode = %q, want allow", cfg.Mode)
+		}
+		if len(cfg.List) != 2 {
+			t.Fatalf("list = %#v, want 2 entries", cfg.List)
+		}
+	})
+
+	t.Run("comma-separated string list", func(t *testing.T) {
+		var cfg ToolFilterConfig
+		if err := json.Unmarshal([]byte(`{
+			"mode": "allow",
+			"list": "confluence_search,jira_get_issue,jira_search"
+		}`), &cfg); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		got := normalizeToolFilterList(cfg.List)
+		want := []string{"confluence_search", "jira_get_issue", "jira_search"}
+		if len(got) != len(want) {
+			t.Fatalf("normalized list = %#v, want %#v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("normalized list = %#v, want %#v", got, want)
+			}
+		}
+	})
+}
+
+func TestNormalizeToolFilterList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "comma separated single entry",
+			in:   []string{"confluence_search,jira_get_issue,jira_search"},
+			want: []string{"confluence_search", "jira_get_issue", "jira_search"},
+		},
+		{
+			name: "trim spaces",
+			in:   []string{" jira_get_issue ", "jira_search"},
+			want: []string{"jira_get_issue", "jira_search"},
+		},
+		{
+			name: "dedupe",
+			in:   []string{"jira_search", "jira_search"},
+			want: []string{"jira_search"},
+		},
+		{
+			name: "mixed array and comma separated",
+			in:   []string{"confluence_search", "jira_get_issue,jira_search"},
+			want: []string{"confluence_search", "jira_get_issue", "jira_search"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeToolFilterList(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %#v, want %#v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %#v, want %#v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildToolFilterFuncAllowList(t *testing.T) {
+	t.Parallel()
+
+	filter := buildToolFilterFunc("atlassian", &OptionsV2{
+		ToolFilter: &ToolFilterConfig{
+			Mode: ToolFilterModeAllow,
+			List: []string{"confluence_search,jira_get_issue,jira_search"},
+		},
+	})
+
+	for _, allowed := range []string{"confluence_search", "jira_get_issue", "jira_search"} {
+		if !filter(allowed) {
+			t.Fatalf("expected %q to be allowed", allowed)
+		}
+	}
+	if filter("jira_create_issue") {
+		t.Fatal("expected jira_create_issue to be blocked")
+	}
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -84,7 +84,7 @@ Common fields:
 - `authTokens` ([]string): Valid bearer tokens; requests must include `Authorization: <token>`.
 - `toolFilter` (object): Selectively expose tools to the proxy:
   - `mode`: `allow` or `block`.
-  - `list`: List of tool names.
+  - `list`: Tool names as a JSON array, or a single comma-separated string (useful when values are injected via environment-variable expansion).
 - `Disabled` (bool): Enable or disable this server. Disabled servers are skipped at startup.
 
 Notes:


### PR DESCRIPTION
## Summary

Normalize `toolFilter.list` entries before allow/block matching so comma-separated values and surrounding whitespace do not cause valid tools to be filtered out.

Fixes #53

## Motivation

Issue #53 reports that tools explicitly listed in an allow-list (e.g. `jira_search`) are still rejected. A common cause is env-expanded config where the list collapses to a single comma-separated string (e.g. `["confluence_search,jira_get_issue,jira_search"]`), which previously matched only the full string and not individual tool names. Trailing/leading whitespace on entries can cause the same symptom.

## Changes

- Add `normalizeToolFilterList` to trim, split comma-separated values, and dedupe entries
- Accept `toolFilter.list` as a JSON array or a single comma-separated string via custom `UnmarshalJSON`
- Extract `buildToolFilterFunc` for testability and log the effective filter set at startup
- Document comma-separated `list` support in `docs/CONFIGURATION.md`
- Add unit tests for parsing, normalization, and allow-list matching

## Tests

- `go test ./... -count=1` — pass
- `go vet ./...` — pass

## Notes

- Matching remains exact (case-sensitive) on normalized tool names; MCP tool names are not expected to contain commas.
- composer-2.5 review: APPROVE