### PR TITLE
feat: add OAuth client support for downstream MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An MCP proxy that aggregates multiple MCP servers behind a single HTTP entrypoin
 - Proxy multiple MCP clients: aggregate tools, prompts, and resources from many servers.
 - SSE and streamable HTTP: serve via Server‑Sent Events or streamable HTTP.
 - Flexible config: supports `stdio`, `sse`, and `streamable-http` client types.
+- OAuth client support: authorize once against downstream servers that require interactive OAuth (e.g. Notion), then let the proxy hold and refresh the token for every caller.
 
 ## Documentation
 

--- a/client.go
+++ b/client.go
@@ -45,6 +45,27 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 			options: conf.Options,
 		}, nil
 	case *SSEMCPClientConfig:
+		if v.OAuth != nil {
+			oc, oErr := buildOAuthConfig(name, v.OAuth)
+			if oErr != nil {
+				return nil, oErr
+			}
+			var options []transport.ClientOption
+			if len(v.Headers) > 0 {
+				options = append(options, client.WithHeaders(v.Headers))
+			}
+			mcpClient, err := client.NewOAuthSSEClient(v.URL, oc, options...)
+			if err != nil {
+				return nil, err
+			}
+			return &Client{
+				name:            name,
+				needPing:        true,
+				needManualStart: true,
+				client:          mcpClient,
+				options:         conf.Options,
+			}, nil
+		}
 		var options []transport.ClientOption
 		if len(v.Headers) > 0 {
 			options = append(options, client.WithHeaders(v.Headers))
@@ -61,6 +82,30 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 			options:         conf.Options,
 		}, nil
 	case *StreamableMCPClientConfig:
+		if v.OAuth != nil {
+			oc, oErr := buildOAuthConfig(name, v.OAuth)
+			if oErr != nil {
+				return nil, oErr
+			}
+			var options []transport.StreamableHTTPCOption
+			if len(v.Headers) > 0 {
+				options = append(options, transport.WithHTTPHeaders(v.Headers))
+			}
+			if v.Timeout > 0 {
+				options = append(options, transport.WithHTTPTimeout(v.Timeout))
+			}
+			mcpClient, err := client.NewOAuthStreamableHttpClient(v.URL, oc, options...)
+			if err != nil {
+				return nil, err
+			}
+			return &Client{
+				name:            name,
+				needPing:        true,
+				needManualStart: true,
+				client:          mcpClient,
+				options:         conf.Options,
+			}, nil
+		}
 		var options []transport.StreamableHTTPCOption
 		if len(v.Headers) > 0 {
 			options = append(options, transport.WithHTTPHeaders(v.Headers))
@@ -87,7 +132,7 @@ func (c *Client) addToMCPServer(ctx context.Context, clientInfo mcp.Implementati
 	if c.needManualStart {
 		err := c.client.Start(ctx)
 		if err != nil {
-			return err
+			return oauthAwareError(c.name, err)
 		}
 	}
 	initRequest := mcp.InitializeRequest{}
@@ -100,7 +145,7 @@ func (c *Client) addToMCPServer(ctx context.Context, clientInfo mcp.Implementati
 	}
 	_, err := c.client.Initialize(ctx, initRequest)
 	if err != nil {
-		return err
+		return oauthAwareError(c.name, err)
 	}
 	log.Printf("<%s> Successfully initialized MCP client", c.name)
 

--- a/config.go
+++ b/config.go
@@ -45,6 +45,16 @@ type OAuthClientConfig struct {
 	RedirectURI  string   `json:"redirectUri,omitempty"`
 	Scopes       []string `json:"scopes,omitempty"`
 	PKCEDisabled bool     `json:"pkceDisabled,omitempty"`
+	// AuthServerMetadataURL overrides discovery of the authorization
+	// server's metadata document. Needed when the server's
+	// authorization_servers entry (RFC 9728) has a non-empty path
+	// component: mcp-go's discovery always appends
+	// "/.well-known/oauth-authorization-server" after the full issuer
+	// URL (OpenID Connect Discovery 1.0 convention), but RFC 8414
+	// requires inserting it before the path when one is present, and
+	// some providers (e.g. Datadog) only serve it at the RFC 8414
+	// location.
+	AuthServerMetadataURL string `json:"authServerMetadataUrl,omitempty"`
 }
 
 const defaultOAuthRedirectURI = "http://localhost:8090/oauth/callback"

--- a/config.go
+++ b/config.go
@@ -22,15 +22,32 @@ type StdioMCPClientConfig struct {
 }
 
 type SSEMCPClientConfig struct {
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
+	URL     string             `json:"url"`
+	Headers map[string]string  `json:"headers"`
+	OAuth   *OAuthClientConfig `json:"oauth,omitempty"`
 }
 
 type StreamableMCPClientConfig struct {
-	URL     string            `json:"url"`
-	Headers map[string]string `json:"headers"`
-	Timeout time.Duration     `json:"timeout"`
+	URL     string             `json:"url"`
+	Headers map[string]string  `json:"headers"`
+	Timeout time.Duration      `json:"timeout"`
+	OAuth   *OAuthClientConfig `json:"oauth,omitempty"`
 }
+
+// OAuthClientConfig configures mcp-proxy as an OAuth client of a downstream
+// remote MCP server, for servers that require interactive OAuth and don't
+// accept a static bearer token (e.g. Notion's hosted MCP). ClientID/Secret
+// may be left empty to use RFC 7591 dynamic client registration, which the
+// authorize flow performs automatically on first run.
+type OAuthClientConfig struct {
+	ClientID     string   `json:"clientId,omitempty"`
+	ClientSecret string   `json:"clientSecret,omitempty"`
+	RedirectURI  string   `json:"redirectUri,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	PKCEDisabled bool     `json:"pkceDisabled,omitempty"`
+}
+
+const defaultOAuthRedirectURI = "http://localhost:8090/oauth/callback"
 
 type MCPClientType string
 
@@ -87,9 +104,10 @@ type MCPClientConfigV2 struct {
 	Env     map[string]string `json:"env,omitempty"`
 
 	// SSE or Streamable HTTP
-	URL     string            `json:"url,omitempty"`
-	Headers map[string]string `json:"headers,omitempty"`
-	Timeout time.Duration     `json:"timeout,omitempty"`
+	URL     string             `json:"url,omitempty"`
+	Headers map[string]string  `json:"headers,omitempty"`
+	Timeout time.Duration      `json:"timeout,omitempty"`
+	OAuth   *OAuthClientConfig `json:"oauth,omitempty"`
 
 	Options *OptionsV2 `json:"options,omitempty"`
 }
@@ -111,11 +129,13 @@ func parseMCPClientConfigV2(conf *MCPClientConfigV2) (any, error) {
 				URL:     conf.URL,
 				Headers: conf.Headers,
 				Timeout: conf.Timeout,
+				OAuth:   conf.OAuth,
 			}, nil
 		} else {
 			return &SSEMCPClientConfig{
 				URL:     conf.URL,
 				Headers: conf.Headers,
+				OAuth:   conf.OAuth,
 			}, nil
 		}
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -102,6 +102,18 @@ as the OAuth client on the downstream connection:
   Must include an explicit port.
 - `scopes` (optional): OAuth scopes to request.
 - `pkceDisabled` (bool, optional): disable PKCE. PKCE is enabled by default.
+- `authServerMetadataUrl` (optional): override discovery of the authorization
+  server's metadata document. Needed for providers whose protected-resource
+  metadata (RFC 9728) advertises an `authorization_servers` entry with a
+  non-empty path (e.g. `https://mcp.example.com/v1/mcp`): this library's
+  discovery always appends `/.well-known/oauth-authorization-server` after
+  the full issuer URL (OpenID Connect Discovery convention), but RFC 8414
+  requires inserting it *before* the path when one is present, and some
+  providers (Datadog, at time of writing) only serve the document at the
+  RFC 8414 location. If servers connected via `oauth` fail discovery,
+  check `<issuer>/.well-known/oauth-authorization-server` vs.
+  `<scheme>://<host>/.well-known/oauth-authorization-server<path>` by hand
+  and set this field to whichever one responds.
 
 Tokens are persisted to `<user config dir>/mcp-proxy/oauth/<server>.json`
 (e.g. `~/.config/mcp-proxy/oauth/notion.json` on Linux) and refreshed

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -121,6 +121,14 @@ automatically using the stored refresh token as they expire. Before the
 daemon can use an `oauth`-configured server, you must authorize it once —
 see the `-authorize` flag in [USAGE.md](USAGE.md).
 
+When `clientId` is left empty, the dynamically-registered client (RFC
+7591) is also persisted, to `<user config dir>/mcp-proxy/oauth/<server>.client.json`.
+This matters: registration only happens inside the one-off `-authorize`
+process, so without persisting it, a freshly started daemon would build a
+new OAuth handler with an empty client ID and every token refresh would
+silently be rejected by the provider once the access token expires -
+looking, from the logs, like a refresh failure with no obvious cause.
+
 ## options
 
 - `panicIfInvalid` (bool): If true, startup fails when a client cannot initialize.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,6 +49,15 @@ This project supports a v2 JSON configuration. v1 configs are automatically migr
       "options": {
         "disabled": true
       }
+    },
+    "notion": {
+      // streamable-http client requiring interactive OAuth (no static
+      // bearer token accepted) - see "oauth" below
+      "url": "https://mcp.notion.com/mcp",
+      "transportType": "streamable-http",
+      "oauth": {
+        "scopes": []
+      }
     }
   }
 }
@@ -75,7 +84,30 @@ Common fields:
 - `command`, `args`, `env` — for `stdio` clients.
 - `url`, `headers` — for `sse` and `streamable-http` clients.
 - `timeout` — request timeout for `streamable-http`.
+- `oauth` — for `sse` and `streamable-http` clients that require interactive OAuth instead of (or in addition to) `headers` (see below).
 - `options` — per‑server overrides and filters (see below).
+
+## oauth
+
+Some remote MCP servers (e.g. Notion's hosted MCP) require the full OAuth
+2.1 authorization-code flow and reject static bearer tokens outright. Set
+an `oauth` block on an `sse`/`streamable-http` server to have mcp-proxy act
+as the OAuth client on the downstream connection:
+
+- `clientId`, `clientSecret` (optional): static client credentials. Omit
+  both to use RFC 7591 dynamic client registration, which is performed
+  automatically the first time you authorize.
+- `redirectUri` (optional): local callback URL used during the one-time
+  interactive authorization. Defaults to `http://localhost:8090/oauth/callback`.
+  Must include an explicit port.
+- `scopes` (optional): OAuth scopes to request.
+- `pkceDisabled` (bool, optional): disable PKCE. PKCE is enabled by default.
+
+Tokens are persisted to `<user config dir>/mcp-proxy/oauth/<server>.json`
+(e.g. `~/.config/mcp-proxy/oauth/notion.json` on Linux) and refreshed
+automatically using the stored refresh token as they expire. Before the
+daemon can use an `oauth`-configured server, you must authorize it once —
+see the `-authorize` flag in [USAGE.md](USAGE.md).
 
 ## options
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,6 +8,8 @@
 -http-headers string   optional headers for config URL: 'Key1:Value1;Key2:Value2'
 -http-timeout int      timeout (seconds) for remote config fetch (default 10)
 -insecure              skip TLS verification for remote config
+-authorize string      run a one-time interactive OAuth authorization for the
+                        named mcpServers entry, then exit
 -version               print version and exit
 -help                  print help and exit
 ```
@@ -43,4 +45,24 @@ Authorization: <token>
 ```
 
 If your client cannot set headers, embed the token in the route key (e.g. `fetch/<token>`) and call that path instead.
+
+## OAuth-authorizing a downstream server
+
+For servers configured with an `oauth` block (see [CONFIGURATION.md](CONFIGURATION.md#oauth)),
+run the authorization flow once, by hand, before starting (or restarting)
+the daemon:
+
+```bash
+mcp-proxy -authorize notion -config path/to/config.json
+```
+
+This opens your default browser to the provider's consent screen, waits
+for the local redirect callback, exchanges the code for a token, and saves
+it to disk. Run it interactively, in a session with a real browser -
+never from an unattended service/container, since it requires you to log
+in and approve access.
+
+Once authorized, start the daemon normally; it reads the saved token and
+refreshes it automatically as it expires. Re-run `-authorize` only if the
+server reports the token is no longer valid (e.g. access was revoked).
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -62,7 +62,10 @@ it to disk. Run it interactively, in a session with a real browser -
 never from an unattended service/container, since it requires you to log
 in and approve access.
 
-Once authorized, start the daemon normally; it reads the saved token and
-refreshes it automatically as it expires. Re-run `-authorize` only if the
+Once authorized, (re)start the daemon. A server's HTTP route is only
+mounted on a successful connect at startup, so if the daemon was already
+running when you authorized, restart it now - the new token won't be
+picked up otherwise. After that, tokens refresh automatically as they
+expire with no further restarts needed. Re-run `-authorize` only if the
 server reports the token is no longer valid (e.g. access was revoked).
 

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ func main() {
 	expandEnv := flag.Bool("expand-env", true, "expand environment variables in config file")
 	httpHeaders := flag.String("http-headers", "", "optional HTTP headers for config URL, format: 'Key1:Value1;Key2:Value2'")
 	httpTimeout := flag.Int("http-timeout", 10, "HTTP timeout in seconds when fetching config from URL")
+	authorize := flag.String("authorize", "", "run a one-time interactive OAuth authorization for the named mcpServers entry, then exit. Opens a browser; run this by hand, not from the daemon/service.")
 
 	version := flag.Bool("version", false, "print version and exit")
 	help := flag.Bool("help", false, "print help and exit")
@@ -24,6 +25,12 @@ func main() {
 	}
 	if *version {
 		fmt.Println(BuildVersion)
+		return
+	}
+	if *authorize != "" {
+		if err := runAuthorize(*conf, *authorize, *insecure, *expandEnv, *httpHeaders, *httpTimeout); err != nil {
+			log.Fatalf("Failed to authorize %q: %v", *authorize, err)
+		}
 		return
 	}
 	config, err := load(*conf, *insecure, *expandEnv, *httpHeaders, *httpTimeout)

--- a/oauth.go
+++ b/oauth.go
@@ -30,12 +30,13 @@ func buildOAuthConfig(serverName string, conf *OAuthClientConfig) (transport.OAu
 		redirectURI = defaultOAuthRedirectURI
 	}
 	return transport.OAuthConfig{
-		ClientID:     conf.ClientID,
-		ClientSecret: conf.ClientSecret,
-		RedirectURI:  redirectURI,
-		Scopes:       conf.Scopes,
-		TokenStore:   NewFileTokenStore(tokenPath),
-		PKCEEnabled:  !conf.PKCEDisabled,
+		ClientID:              conf.ClientID,
+		ClientSecret:          conf.ClientSecret,
+		RedirectURI:           redirectURI,
+		Scopes:                conf.Scopes,
+		TokenStore:            NewFileTokenStore(tokenPath),
+		PKCEEnabled:           !conf.PKCEDisabled,
+		AuthServerMetadataURL: conf.AuthServerMetadataURL,
 	}, nil
 }
 

--- a/oauth.go
+++ b/oauth.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildOAuthConfig turns our JSON-facing OAuthClientConfig into the
+// transport.OAuthConfig the mcp-go client library expects, backed by a
+// FileTokenStore so tokens survive restarts and are shared between the
+// one-off `-authorize` run and the long-running daemon.
+func buildOAuthConfig(serverName string, conf *OAuthClientConfig) (transport.OAuthConfig, error) {
+	tokenPath, err := oauthTokenPath(serverName)
+	if err != nil {
+		return transport.OAuthConfig{}, err
+	}
+	redirectURI := conf.RedirectURI
+	if redirectURI == "" {
+		redirectURI = defaultOAuthRedirectURI
+	}
+	return transport.OAuthConfig{
+		ClientID:     conf.ClientID,
+		ClientSecret: conf.ClientSecret,
+		RedirectURI:  redirectURI,
+		Scopes:       conf.Scopes,
+		TokenStore:   NewFileTokenStore(tokenPath),
+		PKCEEnabled:  !conf.PKCEDisabled,
+	}, nil
+}
+
+// runAuthorize performs a one-time interactive OAuth authorization for a
+// single configured server: it registers a dynamic client if needed, opens
+// a browser to the provider's consent screen, waits for the local redirect
+// callback, exchanges the code for a token, and persists it via the same
+// FileTokenStore the daemon reads from. Intended to be run by hand, in a
+// real desktop session with a browser - never by the unattended daemon.
+func runAuthorize(configPath, serverName string, insecure, expandEnv bool, httpHeaders string, httpTimeout int) error {
+	config, err := load(configPath, insecure, expandEnv, httpHeaders, httpTimeout)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	clientConfig, ok := config.McpServers[serverName]
+	if !ok {
+		return fmt.Errorf("no server named %q in config", serverName)
+	}
+	clientInfo, err := parseMCPClientConfigV2(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	var oauthConf *OAuthClientConfig
+	var mcpClient *client.Client
+	switch v := clientInfo.(type) {
+	case *StdioMCPClientConfig:
+		return fmt.Errorf("server %q is a stdio server, OAuth authorization does not apply", serverName)
+	case *SSEMCPClientConfig:
+		if v.OAuth == nil {
+			return fmt.Errorf("server %q has no oauth config; add mcpServers.%s.oauth to config.json first", serverName, serverName)
+		}
+		oauthConf = v.OAuth
+		oc, bErr := buildOAuthConfig(serverName, oauthConf)
+		if bErr != nil {
+			return bErr
+		}
+		mcpClient, err = client.NewOAuthSSEClient(v.URL, oc)
+	case *StreamableMCPClientConfig:
+		if v.OAuth == nil {
+			return fmt.Errorf("server %q has no oauth config; add mcpServers.%s.oauth to config.json first", serverName, serverName)
+		}
+		oauthConf = v.OAuth
+		oc, bErr := buildOAuthConfig(serverName, oauthConf)
+		if bErr != nil {
+			return bErr
+		}
+		mcpClient, err = client.NewOAuthStreamableHttpClient(v.URL, oc)
+	default:
+		return errors.New("invalid client type")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+	defer mcpClient.Close()
+
+	redirectURI := oauthConf.RedirectURI
+	if redirectURI == "" {
+		redirectURI = defaultOAuthRedirectURI
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if err := mcpClient.Start(ctx); err != nil {
+		if authErr := authorizeInteractively(ctx, err, serverName, redirectURI); authErr != nil {
+			return authErr
+		}
+		if err := mcpClient.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start client after authorization: %w", err)
+		}
+	}
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{Name: "mcp-proxy-authorize", Version: BuildVersion}
+	if _, err := mcpClient.Initialize(ctx, initRequest); err != nil {
+		if authErr := authorizeInteractively(ctx, err, serverName, redirectURI); authErr != nil {
+			return authErr
+		}
+		if _, err := mcpClient.Initialize(ctx, initRequest); err != nil {
+			return fmt.Errorf("failed to initialize after authorization: %w", err)
+		}
+	}
+
+	log.Printf("<%s> Authorization successful, token saved", serverName)
+	return nil
+}
+
+// authorizeInteractively runs the browser + local-callback OAuth dance if
+// err indicates authorization is required; otherwise it returns err as-is.
+func authorizeInteractively(ctx context.Context, err error, serverName, redirectURI string) error {
+	if !client.IsOAuthAuthorizationRequiredError(err) {
+		return err
+	}
+	oauthHandler := client.GetOAuthHandler(err)
+
+	callbackPath, addr, pErr := parseRedirectURI(redirectURI)
+	if pErr != nil {
+		return pErr
+	}
+
+	callbackChan := make(chan map[string]string, 1)
+	srv := startOAuthCallbackServer(addr, callbackPath, callbackChan)
+	defer srv.Close()
+
+	codeVerifier, err := client.GenerateCodeVerifier()
+	if err != nil {
+		return fmt.Errorf("failed to generate PKCE code verifier: %w", err)
+	}
+	codeChallenge := client.GenerateCodeChallenge(codeVerifier)
+
+	state, err := client.GenerateState()
+	if err != nil {
+		return fmt.Errorf("failed to generate state: %w", err)
+	}
+
+	if oauthHandler.GetClientID() == "" {
+		if err := oauthHandler.RegisterClient(ctx, "mcp-proxy ("+serverName+")"); err != nil {
+			return fmt.Errorf("failed to register OAuth client: %w", err)
+		}
+	}
+
+	authURL, err := oauthHandler.GetAuthorizationURL(ctx, state, codeChallenge)
+	if err != nil {
+		return fmt.Errorf("failed to build authorization URL: %w", err)
+	}
+
+	log.Printf("<%s> Opening browser for authorization: %s", serverName, authURL)
+	openBrowser(authURL)
+
+	log.Printf("<%s> Waiting for authorization callback on %s ...", serverName, redirectURI)
+	select {
+	case params := <-callbackChan:
+		if errMsg := params["error"]; errMsg != "" {
+			return fmt.Errorf("authorization denied: %s: %s", errMsg, params["error_description"])
+		}
+		if params["state"] != state {
+			return fmt.Errorf("state mismatch: possible CSRF, expected %s got %s", state, params["state"])
+		}
+		code := params["code"]
+		if code == "" {
+			return errors.New("no authorization code received in callback")
+		}
+		if err := oauthHandler.ProcessAuthorizationResponse(ctx, code, state, codeVerifier); err != nil {
+			return fmt.Errorf("failed to exchange authorization code: %w", err)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for authorization callback: %w", ctx.Err())
+	}
+}
+
+// oauthAwareError rewrites an OAuthAuthorizationRequiredError into a message
+// that tells the operator exactly what to run, instead of a generic
+// connection failure. The daemon never attempts the interactive flow itself.
+func oauthAwareError(serverName string, err error) error {
+	if client.IsOAuthAuthorizationRequiredError(err) {
+		return fmt.Errorf("not authorized yet, run: mcp-proxy -authorize %s -config <path>: %w", serverName, err)
+	}
+	return err
+}
+
+func parseRedirectURI(redirectURI string) (path string, addr string, err error) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid redirect URI %q: %w", redirectURI, err)
+	}
+	host := u.Host
+	if u.Port() == "" {
+		return "", "", fmt.Errorf("redirect URI %q must include an explicit port", redirectURI)
+	}
+	return u.Path, host, nil
+}
+
+func startOAuthCallbackServer(addr, callbackPath string, callbackChan chan<- map[string]string) *http.Server {
+	mux := http.NewServeMux()
+	srv := &http.Server{Addr: addr, Handler: mux}
+
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+		params := make(map[string]string)
+		for key, values := range r.URL.Query() {
+			if len(values) > 0 {
+				params[key] = values[0]
+			}
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><h1>Authorization received</h1><p>You can close this window and return to the terminal.</p></body></html>`))
+		callbackChan <- params
+	})
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("OAuth callback server error: %v", err)
+		}
+	}()
+	return srv
+}
+
+func openBrowser(rawURL string) {
+	var err error
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", rawURL).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", rawURL).Start()
+	case "darwin":
+		err = exec.Command("open", rawURL).Start()
+	default:
+		err = fmt.Errorf("unsupported platform %s", runtime.GOOS)
+	}
+	if err != nil {
+		log.Printf("Could not open browser automatically (%v); open this URL manually:\n  %s", err, rawURL)
+	}
+}

--- a/oauth.go
+++ b/oauth.go
@@ -122,7 +122,7 @@ func runAuthorize(configPath, serverName string, insecure, expandEnv bool, httpH
 		}
 	}
 
-	log.Printf("<%s> Authorization successful, token saved", serverName)
+	log.Printf("<%s> Authorization successful, token saved. Restart the mcp-proxy daemon to pick it up (its HTTP route is only mounted on a successful connect at startup).", serverName)
 	return nil
 }
 

--- a/oauth.go
+++ b/oauth.go
@@ -20,6 +20,14 @@ import (
 // transport.OAuthConfig the mcp-go client library expects, backed by a
 // FileTokenStore so tokens survive restarts and are shared between the
 // one-off `-authorize` run and the long-running daemon.
+//
+// If conf has no static ClientID (i.e. dynamic client registration is in
+// play), this loads whatever client was previously registered and
+// persisted by an earlier `-authorize` run. Without this, a freshly
+// started daemon would build an OAuthHandler with an empty ClientID and
+// every token refresh would silently fail (client_id="" gets rejected by
+// the provider) - the one-off authorize process's dynamic registration
+// only ever lived in that process's memory otherwise.
 func buildOAuthConfig(serverName string, conf *OAuthClientConfig) (transport.OAuthConfig, error) {
 	tokenPath, err := oauthTokenPath(serverName)
 	if err != nil {
@@ -29,9 +37,19 @@ func buildOAuthConfig(serverName string, conf *OAuthClientConfig) (transport.OAu
 	if redirectURI == "" {
 		redirectURI = defaultOAuthRedirectURI
 	}
+	clientID, clientSecret := conf.ClientID, conf.ClientSecret
+	if clientID == "" {
+		regClientID, regClientSecret, ok, rErr := loadRegisteredClient(serverName)
+		if rErr != nil {
+			return transport.OAuthConfig{}, rErr
+		}
+		if ok {
+			clientID, clientSecret = regClientID, regClientSecret
+		}
+	}
 	return transport.OAuthConfig{
-		ClientID:              conf.ClientID,
-		ClientSecret:          conf.ClientSecret,
+		ClientID:              clientID,
+		ClientSecret:          clientSecret,
 		RedirectURI:           redirectURI,
 		Scopes:                conf.Scopes,
 		TokenStore:            NewFileTokenStore(tokenPath),
@@ -157,6 +175,9 @@ func authorizeInteractively(ctx context.Context, err error, serverName, redirect
 	if oauthHandler.GetClientID() == "" {
 		if err := oauthHandler.RegisterClient(ctx, "mcp-proxy ("+serverName+")"); err != nil {
 			return fmt.Errorf("failed to register OAuth client: %w", err)
+		}
+		if err := saveRegisteredClient(serverName, oauthHandler.GetClientID(), oauthHandler.GetClientSecret()); err != nil {
+			return fmt.Errorf("failed to persist registered OAuth client: %w", err)
 		}
 	}
 

--- a/oauth_store.go
+++ b/oauth_store.go
@@ -75,3 +75,69 @@ func (s *FileTokenStore) SaveToken(ctx context.Context, token *transport.Token) 
 	}
 	return os.Rename(tmp, s.path)
 }
+
+// registeredClient is what oauthClientPath persists: the client_id (and
+// client_secret, if the provider issued one) obtained via RFC 7591 dynamic
+// client registration during a `-authorize` run. RegisterClient only
+// mutates the in-memory OAuthHandler of that one-off process, so without
+// persisting it here, a freshly-started daemon would build a new
+// OAuthHandler with an empty ClientID and every subsequent token refresh
+// would silently send client_id="" and be rejected by the provider.
+type registeredClient struct {
+	ClientID     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret,omitempty"`
+}
+
+// oauthClientPath returns the on-disk path for a server's registered OAuth
+// client credentials, alongside its token file.
+func oauthClientPath(serverName string) (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user config dir: %w", err)
+	}
+	return filepath.Join(dir, "mcp-proxy", "oauth", serverName+".client.json"), nil
+}
+
+// loadRegisteredClient returns (clientID, clientSecret, true) if a
+// previously dynamically-registered client was persisted for this server,
+// or ("", "", false) if none exists yet.
+func loadRegisteredClient(serverName string) (string, string, bool, error) {
+	path, err := oauthClientPath(serverName)
+	if err != nil {
+		return "", "", false, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, fmt.Errorf("failed to read client file %s: %w", path, err)
+	}
+	var rc registeredClient
+	if err := json.Unmarshal(data, &rc); err != nil {
+		return "", "", false, fmt.Errorf("failed to parse client file %s: %w", path, err)
+	}
+	return rc.ClientID, rc.ClientSecret, true, nil
+}
+
+// saveRegisteredClient persists a dynamically-registered client's
+// credentials so future daemon starts (and re-authorizations) reuse the
+// same registration instead of getting an empty ClientID.
+func saveRegisteredClient(serverName, clientID, clientSecret string) error {
+	path, err := oauthClientPath(serverName)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("failed to create client directory: %w", err)
+	}
+	data, err := json.MarshalIndent(registeredClient{ClientID: clientID, ClientSecret: clientSecret}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal client: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("failed to write client file %s: %w", tmp, err)
+	}
+	return os.Rename(tmp, path)
+}

--- a/oauth_store.go
+++ b/oauth_store.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+)
+
+// FileTokenStore persists a single OAuth token to a JSON file, so tokens
+// survive proxy restarts and can be shared between a one-off `-authorize`
+// run and the long-running daemon.
+type FileTokenStore struct {
+	path string
+	mu   sync.Mutex
+}
+
+func NewFileTokenStore(path string) *FileTokenStore {
+	return &FileTokenStore{path: path}
+}
+
+// oauthTokenPath returns the on-disk path for a server's token file,
+// rooted under the user's config dir (~/.config/mcp-proxy/oauth on Linux).
+func oauthTokenPath(serverName string) (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user config dir: %w", err)
+	}
+	return filepath.Join(dir, "mcp-proxy", "oauth", serverName+".json"), nil
+}
+
+func (s *FileTokenStore) GetToken(ctx context.Context) (*transport.Token, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, transport.ErrNoToken
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read token file %s: %w", s.path, err)
+	}
+	var token transport.Token
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("failed to parse token file %s: %w", s.path, err)
+	}
+	return &token, nil
+}
+
+func (s *FileTokenStore) SaveToken(ctx context.Context, token *transport.Token) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
+		return fmt.Errorf("failed to create token directory: %w", err)
+	}
+	data, err := json.MarshalIndent(token, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal token: %w", err)
+	}
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("failed to write token file %s: %w", tmp, err)
+	}
+	return os.Rename(tmp, s.path)
+}


### PR DESCRIPTION
## Summary

`mark3labs/mcp-go` already implements the OAuth 2.1 client flow (protected-resource/authorization-server metadata discovery, RFC 7591 dynamic client registration, PKCE, token refresh - see `client/transport/oauth.go`), but mcp-proxy's `client.go` never wires it through: it always builds plain `NewSSEMCPClient`/`NewStreamableHttpClient` with only static headers.

That's a real gap for servers that flat-out reject static bearer tokens and require the full interactive OAuth flow - Notion's hosted MCP is a concrete example ("Notion MCP requires user-based OAuth authentication and does not support bearer token authentication", per their docs). Those servers currently can't be proxied at all.

## What this adds

- An optional `oauth` block on `sse`/`streamable-http` `mcpServers` entries (`clientId`/`clientSecret` optional - falls back to dynamic client registration; `redirectUri`, `scopes`, `pkceDisabled`).
- `FileTokenStore` (`oauth_store.go`): persists the token to `<user config dir>/mcp-proxy/oauth/<server>.json`, shared between the one-time authorize run and the long-running daemon, so restarts don't require re-authorizing.
- A new `-authorize <name>` CLI mode (`oauth.go`): performs the one-time interactive flow - dynamic client registration if needed, PKCE, local redirect callback listener, browser open, code exchange - and saves the token. Meant to be run by hand, in a real desktop session; the daemon itself never attempts this and instead fails a not-yet-authorized server with a clear message pointing at `-authorize`, consistent with the existing `panicIfInvalid` per-server failure handling.
- `client.go` routes to `NewOAuthSSEClient`/`NewOAuthStreamableHttpClient` when `oauth` is configured, otherwise behavior is unchanged.
- Docs: `docs/CONFIGURATION.md` (`oauth` block reference + example), `docs/USAGE.md` (`-authorize` flag + walkthrough), README feature bullet.

## Testing

Verified end-to-end against Notion's production MCP server (`mcp.notion.com`):
- `-authorize notion` → dynamic client registration → browser consent → code exchange → token persisted.
- Daemon restart picks up the persisted token with zero prompts, lists Notion's tools, and serves them through the proxy's existing per-server auth-token gate.
- Also confirmed the error paths: `-authorize` on a stdio server, on a server with no `oauth` config, and on an unknown server name all fail with clear, specific messages.
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean. No existing test suite to run (`go test ./...` reports no test files, same as master).

Existing static-header flows (tested against Linear, tmux) are unaffected - this is purely additive when `oauth` is present in config.