### PR TITLE
fix: harden OAuth and configuration handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -147,7 +147,7 @@ func (c *Client) addToMCPServer(ctx context.Context, clientInfo mcp.Implementati
 	if err != nil {
 		return oauthAwareError(c.name, err)
 	}
-	log.Printf("<%s> Successfully initialized MCP client", c.name)
+	slog.Info("Successfully initialized MCP client", "client", c.name)
 
 	err = c.addToolsToServer(ctx, mcpServer)
 	if err != nil {
@@ -172,7 +172,7 @@ func (c *Client) startPingTask(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Printf("<%s> Context done, stopping ping", c.name)
+			slog.Debug("Context done, stopping ping", "client", c.name)
 			return
 		case <-ticker.C:
 			if err := c.client.Ping(ctx); err != nil {
@@ -180,9 +180,9 @@ func (c *Client) startPingTask(ctx context.Context) {
 					return
 				}
 				failCount++
-				log.Printf("<%s> MCP Ping failed: %v (count=%d)", c.name, err, failCount)
+				slog.Warn("MCP ping failed", "client", c.name, "err", err, "failures", failCount)
 			} else if failCount > 0 {
-				log.Printf("<%s> MCP Ping recovered after %d failures", c.name, failCount)
+				slog.Info("MCP ping recovered", "client", c.name, "failures", failCount)
 				failCount = 0
 			}
 		}
@@ -206,7 +206,7 @@ func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServ
 			filterFunc = func(toolName string) bool {
 				_, inList := filterSet[toolName]
 				if !inList {
-					log.Printf("<%s> Ignoring tool %s as it is not in allow list", c.name, toolName)
+					slog.Debug("Ignoring tool not in allow list", "client", c.name, "tool", toolName)
 				}
 				return inList
 			}
@@ -214,12 +214,12 @@ func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServ
 			filterFunc = func(toolName string) bool {
 				_, inList := filterSet[toolName]
 				if inList {
-					log.Printf("<%s> Ignoring tool %s as it is in block list", c.name, toolName)
+					slog.Debug("Ignoring tool in block list", "client", c.name, "tool", toolName)
 				}
 				return !inList
 			}
 		default:
-			log.Printf("<%s> Unknown tool filter mode: %s, skipping tool filter", c.name, mode)
+			slog.Warn("Unknown tool filter mode, skipping tool filter", "client", c.name, "mode", mode)
 		}
 	}
 
@@ -234,10 +234,10 @@ func (c *Client) addToolsToServer(ctx context.Context, mcpServer *server.MCPServ
 		if len(tools.Tools) == 0 {
 			break
 		}
-		log.Printf("<%s> Successfully listed %d tools", c.name, len(tools.Tools))
+		slog.Debug("Successfully listed tools", "client", c.name, "count", len(tools.Tools))
 		for _, tool := range tools.Tools {
 			if filterFunc(tool.Name) {
-				log.Printf("<%s> Adding tool %s", c.name, tool.Name)
+				slog.Debug("Adding tool", "client", c.name, "tool", tool.Name)
 				mcpServer.AddTool(tool, c.client.CallTool)
 			}
 		}
@@ -263,9 +263,9 @@ func (c *Client) addPromptsToServer(ctx context.Context, mcpServer *server.MCPSe
 		if len(prompts.Prompts) == 0 {
 			break
 		}
-		log.Printf("<%s> Successfully listed %d prompts", c.name, len(prompts.Prompts))
+		slog.Debug("Successfully listed prompts", "client", c.name, "count", len(prompts.Prompts))
 		for _, prompt := range prompts.Prompts {
-			log.Printf("<%s> Adding prompt %s", c.name, prompt.Name)
+			slog.Debug("Adding prompt", "client", c.name, "prompt", prompt.Name)
 			mcpServer.AddPrompt(prompt, c.client.GetPrompt)
 		}
 		if prompts.NextCursor == "" {
@@ -289,9 +289,9 @@ func (c *Client) addResourcesToServer(ctx context.Context, mcpServer *server.MCP
 		if len(resources.Resources) == 0 {
 			break
 		}
-		log.Printf("<%s> Successfully listed %d resources", c.name, len(resources.Resources))
+		slog.Debug("Successfully listed resources", "client", c.name, "count", len(resources.Resources))
 		for _, resource := range resources.Resources {
-			log.Printf("<%s> Adding resource %s", c.name, resource.Name)
+			slog.Debug("Adding resource", "client", c.name, "resource", resource.Name)
 			mcpServer.AddResource(resource, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 				readResource, e := c.client.ReadResource(ctx, request)
 				if e != nil {
@@ -319,9 +319,9 @@ func (c *Client) addResourceTemplatesToServer(ctx context.Context, mcpServer *se
 		if resourceTemplates == nil || len(resourceTemplates.ResourceTemplates) == 0 {
 			break
 		}
-		log.Printf("<%s> Successfully listed %d resource templates", c.name, len(resourceTemplates.ResourceTemplates))
+		slog.Debug("Successfully listed resource templates", "client", c.name, "count", len(resourceTemplates.ResourceTemplates))
 		for _, resourceTemplate := range resourceTemplates.ResourceTemplates {
-			log.Printf("<%s> Adding resource template %s", c.name, resourceTemplate.Name)
+			slog.Debug("Adding resource template", "client", c.name, "template", resourceTemplate.Name)
 			mcpServer.AddResourceTemplate(resourceTemplate, func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 				readResource, e := c.client.ReadResource(ctx, request)
 				if e != nil {
@@ -352,12 +352,22 @@ type Server struct {
 }
 
 func newMCPServer(name string, serverConfig *MCPProxyConfigV2, clientConfig *MCPClientConfigV2) (*Server, error) {
+	if serverConfig == nil {
+		return nil, errors.New("server config is required")
+	}
+	if clientConfig == nil {
+		return nil, errors.New("client config is required")
+	}
+	clientOptions := clientConfig.Options
+	if clientOptions == nil {
+		clientOptions = &OptionsV2{}
+	}
 	serverOpts := []server.ServerOption{
 		server.WithResourceCapabilities(true, true),
 		server.WithRecovery(),
 	}
 
-	if clientConfig.Options.LogEnabled.OrElse(false) {
+	if clientOptions.LogEnabled.OrElse(false) {
 		serverOpts = append(serverOpts, server.WithLogging())
 	}
 	mcpServer := server.NewMCPServer(
@@ -388,8 +398,8 @@ func newMCPServer(name string, serverConfig *MCPProxyConfigV2, clientConfig *MCP
 		handler:   handler,
 	}
 
-	if clientConfig.Options != nil && len(clientConfig.Options.AuthTokens) > 0 {
-		srv.tokens = clientConfig.Options.AuthTokens
+	if len(clientOptions.AuthTokens) > 0 {
+		srv.tokens = clientOptions.AuthTokens
 	}
 
 	return srv, nil

--- a/config.go
+++ b/config.go
@@ -3,7 +3,9 @@ package main
 import (
 	"crypto/tls"
 	"errors"
+	"fmt"
 	nethttp "net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -123,33 +125,162 @@ type MCPClientConfigV2 struct {
 }
 
 func parseMCPClientConfigV2(conf *MCPClientConfigV2) (any, error) {
-	if conf.Command != "" || conf.TransportType == MCPClientTypeStdio {
+	if conf == nil {
+		return nil, errors.New("server config is null")
+	}
+	if conf.Command != "" && conf.URL != "" {
+		return nil, errors.New("command and url are mutually exclusive")
+	}
+
+	transportType := conf.TransportType
+	if transportType == "" {
+		switch {
+		case conf.Command != "":
+			transportType = MCPClientTypeStdio
+		case conf.URL != "":
+			transportType = MCPClientTypeSSE
+		default:
+			return nil, errors.New("command or url is required")
+		}
+	}
+
+	switch transportType {
+	case MCPClientTypeStdio:
 		if conf.Command == "" {
 			return nil, errors.New("command is required for stdio transport")
+		}
+		if conf.OAuth != nil {
+			return nil, errors.New("oauth is not supported for stdio transport")
 		}
 		return &StdioMCPClientConfig{
 			Command: conf.Command,
 			Env:     conf.Env,
 			Args:    conf.Args,
 		}, nil
+	case MCPClientTypeSSE:
+		if conf.URL == "" {
+			return nil, errors.New("url is required for sse transport")
+		}
+		return &SSEMCPClientConfig{
+			URL:     conf.URL,
+			Headers: conf.Headers,
+			OAuth:   conf.OAuth,
+		}, nil
+	case MCPClientTypeStreamable:
+		if conf.URL == "" {
+			return nil, errors.New("url is required for streamable-http transport")
+		}
+		if conf.Timeout < 0 {
+			return nil, errors.New("timeout cannot be negative")
+		}
+		return &StreamableMCPClientConfig{
+			URL:     conf.URL,
+			Headers: conf.Headers,
+			Timeout: conf.Timeout,
+			OAuth:   conf.OAuth,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported transportType %q", conf.TransportType)
 	}
-	if conf.URL != "" {
-		if conf.TransportType == MCPClientTypeStreamable {
-			return &StreamableMCPClientConfig{
-				URL:     conf.URL,
-				Headers: conf.Headers,
-				Timeout: conf.Timeout,
-				OAuth:   conf.OAuth,
-			}, nil
-		} else {
-			return &SSEMCPClientConfig{
-				URL:     conf.URL,
-				Headers: conf.Headers,
-				OAuth:   conf.OAuth,
-			}, nil
+}
+
+func validateHTTPURL(field, rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("%s is invalid: %w", field, err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("%s must be an absolute http(s) URL", field)
+	}
+	return nil
+}
+
+func validateOptions(field string, options *OptionsV2) error {
+	if options == nil {
+		return nil
+	}
+	for i, token := range options.AuthTokens {
+		if strings.TrimSpace(token) == "" {
+			return fmt.Errorf("%s.authTokens[%d] cannot be empty", field, i)
 		}
 	}
-	return nil, errors.New("invalid server type")
+	if options.ToolFilter == nil {
+		return nil
+	}
+	mode := ToolFilterMode(strings.ToLower(string(options.ToolFilter.Mode)))
+	if mode != ToolFilterModeAllow && mode != ToolFilterModeBlock {
+		return fmt.Errorf("%s.toolFilter.mode must be %q or %q", field, ToolFilterModeAllow, ToolFilterModeBlock)
+	}
+	for i, toolName := range options.ToolFilter.List {
+		if strings.TrimSpace(toolName) == "" {
+			return fmt.Errorf("%s.toolFilter.list[%d] cannot be empty", field, i)
+		}
+	}
+	return nil
+}
+
+func validateConfig(config *Config) error {
+	if config == nil || config.McpProxy == nil {
+		return errors.New("mcpProxy is required")
+	}
+	proxy := config.McpProxy
+	if err := validateHTTPURL("mcpProxy.baseURL", proxy.BaseURL); err != nil {
+		return err
+	}
+	if strings.TrimSpace(proxy.Addr) == "" {
+		return errors.New("mcpProxy.addr is required")
+	}
+	if strings.TrimSpace(proxy.Name) == "" {
+		return errors.New("mcpProxy.name is required")
+	}
+	if strings.TrimSpace(proxy.Version) == "" {
+		return errors.New("mcpProxy.version is required")
+	}
+	if proxy.Type != MCPServerTypeSSE && proxy.Type != MCPServerTypeStreamable {
+		return fmt.Errorf("mcpProxy.type must be %q or %q", MCPServerTypeSSE, MCPServerTypeStreamable)
+	}
+	if err := validateOptions("mcpProxy.options", proxy.Options); err != nil {
+		return err
+	}
+
+	for name, serverConfig := range config.McpServers {
+		field := fmt.Sprintf("mcpServers[%q]", name)
+		if strings.TrimSpace(name) == "" {
+			return errors.New("mcpServers contains an empty server name")
+		}
+		if serverConfig == nil {
+			return fmt.Errorf("%s cannot be null", field)
+		}
+		if _, err := parseMCPClientConfigV2(serverConfig); err != nil {
+			return fmt.Errorf("%s: %w", field, err)
+		}
+		if serverConfig.URL != "" {
+			if err := validateHTTPURL(field+".url", serverConfig.URL); err != nil {
+				return err
+			}
+		}
+		if err := validateOptions(field+".options", serverConfig.Options); err != nil {
+			return err
+		}
+		if serverConfig.OAuth != nil {
+			if serverConfig.OAuth.ClientID == "" && serverConfig.OAuth.ClientSecret != "" {
+				return fmt.Errorf("%s.oauth.clientSecret requires clientId", field)
+			}
+			redirectURI := serverConfig.OAuth.RedirectURI
+			if redirectURI == "" {
+				redirectURI = defaultOAuthRedirectURI
+			}
+			if _, _, err := parseRedirectURI(redirectURI); err != nil {
+				return fmt.Errorf("%s.oauth.redirectUri: %w", field, err)
+			}
+			if metadataURL := serverConfig.OAuth.AuthServerMetadataURL; metadataURL != "" {
+				if err := validateHTTPURL(field+".oauth.authServerMetadataUrl", metadataURL); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // ---- Config ----
@@ -231,7 +362,10 @@ func load(path string, insecure, expandEnv bool, httpHeaders string, httpTimeout
 	if conf.McpProxy.Options == nil {
 		conf.McpProxy.Options = &OptionsV2{}
 	}
-	for _, clientConfig := range conf.McpServers {
+	for name, clientConfig := range conf.McpServers {
+		if clientConfig == nil {
+			return nil, fmt.Errorf("mcpServers[%q] cannot be null", name)
+		}
 		if clientConfig.Options == nil {
 			clientConfig.Options = &OptionsV2{}
 		}
@@ -250,8 +384,12 @@ func load(path string, insecure, expandEnv bool, httpHeaders string, httpTimeout
 		conf.McpProxy.Type = MCPServerTypeSSE // default to SSE
 	}
 
-	return &Config{
+	config := &Config{
 		McpProxy:   conf.McpProxy,
 		McpServers: conf.McpServers,
-	}, nil
+	}
+	if err := validateConfig(config); err != nil {
+		return nil, err
+	}
+	return config, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func validTestConfig() *Config {
+	return &Config{
+		McpProxy: &MCPProxyConfigV2{
+			BaseURL: "http://localhost:9090",
+			Addr:    ":9090",
+			Name:    "test-proxy",
+			Version: "test",
+			Type:    MCPServerTypeStreamable,
+			Options: &OptionsV2{},
+		},
+		McpServers: map[string]*MCPClientConfigV2{
+			"stdio": {
+				Command: "test-server",
+				Options: &OptionsV2{},
+			},
+		},
+	}
+}
+
+func TestParseMCPClientConfigV2(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  *MCPClientConfigV2
+		wantErr string
+		want    any
+	}{
+		{name: "infer stdio", config: &MCPClientConfigV2{Command: "server"}, want: &StdioMCPClientConfig{}},
+		{name: "infer sse", config: &MCPClientConfigV2{URL: "https://example.com/sse"}, want: &SSEMCPClientConfig{}},
+		{name: "explicit streamable", config: &MCPClientConfigV2{TransportType: MCPClientTypeStreamable, URL: "https://example.com/mcp"}, want: &StreamableMCPClientConfig{}},
+		{name: "null", config: nil, wantErr: "server config is null"},
+		{name: "ambiguous", config: &MCPClientConfigV2{Command: "server", URL: "https://example.com"}, wantErr: "mutually exclusive"},
+		{name: "missing endpoint", config: &MCPClientConfigV2{}, wantErr: "command or url is required"},
+		{name: "unknown transport", config: &MCPClientConfigV2{TransportType: "websocket", URL: "https://example.com"}, wantErr: "unsupported transportType"},
+		{name: "stdio missing command", config: &MCPClientConfigV2{TransportType: MCPClientTypeStdio}, wantErr: "command is required"},
+		{name: "oauth on stdio", config: &MCPClientConfigV2{Command: "server", OAuth: &OAuthClientConfig{}}, wantErr: "oauth is not supported"},
+		{name: "negative timeout", config: &MCPClientConfigV2{TransportType: MCPClientTypeStreamable, URL: "https://example.com", Timeout: -1}, wantErr: "timeout cannot be negative"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseMCPClientConfigV2(tt.config)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse config: %v", err)
+			}
+			switch tt.want.(type) {
+			case *StdioMCPClientConfig:
+				if _, ok := got.(*StdioMCPClientConfig); !ok {
+					t.Fatalf("type = %T, want *StdioMCPClientConfig", got)
+				}
+			case *SSEMCPClientConfig:
+				if _, ok := got.(*SSEMCPClientConfig); !ok {
+					t.Fatalf("type = %T, want *SSEMCPClientConfig", got)
+				}
+			case *StreamableMCPClientConfig:
+				if _, ok := got.(*StreamableMCPClientConfig); !ok {
+					t.Fatalf("type = %T, want *StreamableMCPClientConfig", got)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid", func(t *testing.T) {
+		if err := validateConfig(validTestConfig()); err != nil {
+			t.Fatalf("validate config: %v", err)
+		}
+	})
+
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{name: "invalid base URL", mutate: func(c *Config) { c.McpProxy.BaseURL = "localhost:9090" }, wantErr: "absolute http(s) URL"},
+		{name: "unknown proxy type", mutate: func(c *Config) { c.McpProxy.Type = "websocket" }, wantErr: "mcpProxy.type"},
+		{name: "empty token", mutate: func(c *Config) { c.McpServers["stdio"].Options.AuthTokens = []string{""} }, wantErr: "authTokens[0]"},
+		{name: "unknown filter mode", mutate: func(c *Config) {
+			c.McpServers["stdio"].Options.ToolFilter = &ToolFilterConfig{Mode: "permit", List: []string{"tool"}}
+		}, wantErr: "toolFilter.mode"},
+		{name: "invalid remote URL", mutate: func(c *Config) {
+			c.McpServers["stdio"] = &MCPClientConfigV2{URL: "://bad", Options: &OptionsV2{}}
+		}, wantErr: "is invalid"},
+		{name: "non-loopback OAuth redirect", mutate: func(c *Config) {
+			c.McpServers["stdio"] = &MCPClientConfigV2{
+				URL:     "https://example.com/mcp",
+				OAuth:   &OAuthClientConfig{RedirectURI: "http://0.0.0.0:8090/oauth/callback"},
+				Options: &OptionsV2{},
+			}
+		}, wantErr: "loopback"},
+		{name: "secret without client ID", mutate: func(c *Config) {
+			c.McpServers["stdio"] = &MCPClientConfigV2{
+				URL:     "https://example.com/mcp",
+				OAuth:   &OAuthClientConfig{ClientSecret: "secret"},
+				Options: &OptionsV2{},
+			}
+		}, wantErr: "clientSecret requires clientId"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := validTestConfig()
+			tt.mutate(config)
+			err := validateConfig(config)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsInvalidServerConfig(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	data := []byte(`{
+		"mcpProxy": {
+			"baseURL": "http://localhost:9090",
+			"addr": ":9090",
+			"name": "test",
+			"version": "test",
+			"type": "streamable-http"
+		},
+		"mcpServers": {
+			"broken": {"transportType": "streamable-http"}
+		}
+	}`)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := load(path, false, false, "", 10)
+	if err == nil || !strings.Contains(err.Error(), `mcpServers["broken"]`) {
+		t.Fatalf("load error = %v, want broken server context", err)
+	}
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -99,7 +99,9 @@ as the OAuth client on the downstream connection:
   automatically the first time you authorize.
 - `redirectUri` (optional): local callback URL used during the one-time
   interactive authorization. Defaults to `http://localhost:8090/oauth/callback`.
-  Must include an explicit port.
+  It must use `http`, a loopback host (`localhost`, `127.0.0.1`, or `::1`), an
+  explicit port, and a non-root callback path. The callback listener never
+  binds to a public interface.
 - `scopes` (optional): OAuth scopes to request.
 - `pkceDisabled` (bool, optional): disable PKCE. PKCE is enabled by default.
 - `authServerMetadataUrl` (optional): override discovery of the authorization
@@ -143,4 +145,3 @@ Notes:
 
 - `mcpProxy.options.authTokens` serves as the default token set if a server omits `options.authTokens`.
 - To discover tool names for filtering, start without a filter and check logs for lines like `<server> Adding tool <name>`.
-

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,9 +10,25 @@
 -insecure              skip TLS verification for remote config
 -authorize string      run a one-time interactive OAuth authorization for the
                         named mcpServers entry, then exit
+-check-config          load and validate the config, then exit
+-log-level value       log level: debug, info, warn, or error (default info)
 -version               print version and exit
 -help                  print help and exit
 ```
+
+## Validating configuration
+
+Use `-check-config` in CI, init containers, or deployment scripts to validate
+the proxy settings and every downstream server without binding the HTTP port:
+
+```bash
+mcp-proxy -config config.json -check-config
+# Config OK: 3 MCP server(s) configured
+```
+
+Validation includes transport requirements, absolute HTTP URLs, OAuth callback
+safety, authentication tokens, and tool-filter modes. Invalid configuration
+exits non-zero with the affected field or server name.
 
 ## Endpoints
 
@@ -68,4 +84,3 @@ running when you authorized, restart it now - the new token won't be
 picked up otherwise. After that, tokens refresh automatically as they
 expire with no further restarts needed. Re-run `-authorize` only if the
 server reports the token is no longer valid (e.g. access was revoked).
-

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/http.go
+++ b/http.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -54,7 +55,7 @@ func newAuthMiddleware(tokens []string) MiddlewareFunc {
 func loggerMiddleware(prefix string) MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log.Printf("<%s> Request [%s] %s", prefix, r.Method, r.URL.Path)
+			slog.Info("Request", "client", prefix, "method", r.Method, "path", r.URL.Path)
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -65,7 +66,7 @@ func recoverMiddleware(prefix string) MiddlewareFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
 				if err := recover(); err != nil {
-					log.Printf("<%s> Recovered from panic: %v", prefix, err)
+					slog.Error("Recovered from panic", "client", prefix, "err", err)
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 				}
 			}()
@@ -123,6 +124,7 @@ func startHTTPServer(config *Config) error {
 	info := mcp.Implementation{
 		Name: config.McpProxy.Name,
 	}
+	clients := make(map[string]*Client, len(config.McpServers))
 
 	// Unauthenticated health endpoints for liveness/readiness probes.
 	health := healthHandler(config)
@@ -131,7 +133,7 @@ func startHTTPServer(config *Config) error {
 
 	for name, clientConfig := range config.McpServers {
 		if clientConfig.Options.Disabled {
-			log.Printf("<%s> Disabled", name)
+			slog.Info("Disabled", "client", name)
 			continue
 		}
 		mcpClient, err := newMCPClient(name, clientConfig)
@@ -142,17 +144,18 @@ func startHTTPServer(config *Config) error {
 		if err != nil {
 			return err
 		}
+		clients[name] = mcpClient
 		errorGroup.Go(func() error {
-			log.Printf("<%s> Connecting", name)
+			slog.Info("Connecting", "client", name)
 			addErr := mcpClient.addToMCPServer(ctx, info, server.mcpServer)
 			if addErr != nil {
-				log.Printf("<%s> Failed to add client to server: %v", name, addErr)
+				slog.Error("Failed to add client to server", "client", name, "err", addErr)
 				if clientConfig.Options.PanicIfInvalid.OrElse(false) {
 					return addErr
 				}
 				return nil
 			}
-			log.Printf("<%s> Connected", name)
+			slog.Info("Connected", "client", name)
 
 			middlewares := make([]MiddlewareFunc, 0)
 			middlewares = append(middlewares, recoverMiddleware(name))
@@ -169,45 +172,66 @@ func startHTTPServer(config *Config) error {
 			if !strings.HasSuffix(mcpRoute, "/") {
 				mcpRoute += "/"
 			}
-			log.Printf("<%s> Handling requests at %s", name, mcpRoute)
+			slog.Info("Handling requests", "client", name, "route", mcpRoute)
 			httpMux.Handle(mcpRoute, chainMiddleware(server.handler, middlewares...))
-			httpServer.RegisterOnShutdown(func() {
-				log.Printf("<%s> Shutting down", name)
-				_ = mcpClient.Close()
-			})
 			return nil
 		})
 	}
 
+	initializationDone := make(chan error, 1)
 	go func() {
-		err := errorGroup.Wait()
-		if err != nil {
-			log.Fatalf("Failed to add clients: %v", err)
-		}
-		log.Printf("All clients initialized")
+		initializationDone <- errorGroup.Wait()
 	}()
 
+	serverDone := make(chan error, 1)
 	go func() {
-		log.Printf("Starting %s server", config.McpProxy.Type)
-		log.Printf("%s server listening on %s", config.McpProxy.Type, config.McpProxy.Addr)
+		slog.Info("Starting server", "type", config.McpProxy.Type, "addr", config.McpProxy.Addr)
 		hErr := httpServer.ListenAndServe()
-		if hErr != nil && !errors.Is(hErr, http.ErrServerClosed) {
-			log.Fatalf("Failed to start server: %v", hErr)
+		if errors.Is(hErr, http.ErrServerClosed) {
+			hErr = nil
 		}
+		serverDone <- hErr
 	}()
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 
-	<-sigChan
-	log.Println("Shutdown signal received")
-
-	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
-	defer shutdownCancel()
-
-	err := httpServer.Shutdown(shutdownCtx)
-	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		return err
+	shutdown := func() error {
+		cancel()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		var shutdownErrors []error
+		if err := httpServer.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			shutdownErrors = append(shutdownErrors, err)
+		}
+		for name, client := range clients {
+			slog.Info("Shutting down", "client", name)
+			if err := client.Close(); err != nil {
+				shutdownErrors = append(shutdownErrors, fmt.Errorf("close client %q: %w", name, err))
+			}
+		}
+		return errors.Join(shutdownErrors...)
 	}
-	return nil
+
+	for {
+		select {
+		case err := <-initializationDone:
+			initializationDone = nil
+			if err != nil {
+				_ = shutdown()
+				return fmt.Errorf("failed to initialize clients: %w", err)
+			}
+			slog.Info("All clients initialized")
+		case err := <-serverDone:
+			_ = shutdown()
+			if err != nil {
+				return fmt.Errorf("HTTP server failed: %w", err)
+			}
+			return nil
+		case <-sigChan:
+			slog.Info("Shutdown signal received")
+			return shutdown()
+		}
+	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestStartHTTPServerReturnsListenError(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve address: %v", err)
+	}
+	defer listener.Close()
+
+	config := &Config{
+		McpProxy: &MCPProxyConfigV2{
+			BaseURL: "http://" + listener.Addr().String(),
+			Addr:    listener.Addr().String(),
+			Name:    "test",
+			Version: "test",
+			Type:    MCPServerTypeStreamable,
+			Options: &OptionsV2{},
+		},
+		McpServers: map[string]*MCPClientConfigV2{},
+	}
+
+	err = startHTTPServer(config)
+	if err == nil || !strings.Contains(err.Error(), "HTTP server failed") {
+		t.Fatalf("startHTTPServer error = %v, want listen failure", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -3,7 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
+	"os"
 )
 
 var BuildVersion = "dev"
@@ -15,6 +16,9 @@ func main() {
 	httpHeaders := flag.String("http-headers", "", "optional HTTP headers for config URL, format: 'Key1:Value1;Key2:Value2'")
 	httpTimeout := flag.Int("http-timeout", 10, "HTTP timeout in seconds when fetching config from URL")
 	authorize := flag.String("authorize", "", "run a one-time interactive OAuth authorization for the named mcpServers entry, then exit. Opens a browser; run this by hand, not from the daemon/service.")
+	checkConfig := flag.Bool("check-config", false, "load and validate the config, then exit without starting the server")
+	var logLevel slog.Level
+	flag.TextVar(&logLevel, "log-level", slog.LevelInfo, "log level (debug, info, warn, error)")
 
 	version := flag.Bool("version", false, "print version and exit")
 	help := flag.Bool("help", false, "print help and exit")
@@ -27,18 +31,26 @@ func main() {
 		fmt.Println(BuildVersion)
 		return
 	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel})))
 	if *authorize != "" {
 		if err := runAuthorize(*conf, *authorize, *insecure, *expandEnv, *httpHeaders, *httpTimeout); err != nil {
-			log.Fatalf("Failed to authorize %q: %v", *authorize, err)
+			slog.Error("Failed to authorize server", "server", *authorize, "err", err)
+			os.Exit(1)
 		}
 		return
 	}
 	config, err := load(*conf, *insecure, *expandEnv, *httpHeaders, *httpTimeout)
 	if err != nil {
-		log.Fatalf("Failed to load config: %v", err)
+		slog.Error("Failed to load config", "err", err)
+		os.Exit(1)
+	}
+	if *checkConfig {
+		fmt.Printf("Config OK: %d MCP server(s) configured\n", len(config.McpServers))
+		return
 	}
 	err = startHTTPServer(config)
 	if err != nil {
-		log.Fatalf("Failed to start server: %v", err)
+		slog.Error("Failed to start server", "err", err)
+		os.Exit(1)
 	}
 }

--- a/oauth.go
+++ b/oauth.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os/exec"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mark3labs/mcp-go/client"
@@ -92,7 +95,11 @@ func runAuthorize(configPath, serverName string, insecure, expandEnv bool, httpH
 		if bErr != nil {
 			return bErr
 		}
-		mcpClient, err = client.NewOAuthSSEClient(v.URL, oc)
+		var options []transport.ClientOption
+		if len(v.Headers) > 0 {
+			options = append(options, client.WithHeaders(v.Headers))
+		}
+		mcpClient, err = client.NewOAuthSSEClient(v.URL, oc, options...)
 	case *StreamableMCPClientConfig:
 		if v.OAuth == nil {
 			return fmt.Errorf("server %q has no oauth config; add mcpServers.%s.oauth to config.json first", serverName, serverName)
@@ -102,7 +109,14 @@ func runAuthorize(configPath, serverName string, insecure, expandEnv bool, httpH
 		if bErr != nil {
 			return bErr
 		}
-		mcpClient, err = client.NewOAuthStreamableHttpClient(v.URL, oc)
+		var options []transport.StreamableHTTPCOption
+		if len(v.Headers) > 0 {
+			options = append(options, transport.WithHTTPHeaders(v.Headers))
+		}
+		if v.Timeout > 0 {
+			options = append(options, transport.WithHTTPTimeout(v.Timeout))
+		}
+		mcpClient, err = client.NewOAuthStreamableHttpClient(v.URL, oc, options...)
 	default:
 		return errors.New("invalid client type")
 	}
@@ -140,7 +154,7 @@ func runAuthorize(configPath, serverName string, insecure, expandEnv bool, httpH
 		}
 	}
 
-	log.Printf("<%s> Authorization successful, token saved. Restart the mcp-proxy daemon to pick it up (its HTTP route is only mounted on a successful connect at startup).", serverName)
+	slog.Info("Authorization successful; restart the daemon to mount the server route", "server", serverName)
 	return nil
 }
 
@@ -157,10 +171,6 @@ func authorizeInteractively(ctx context.Context, err error, serverName, redirect
 		return pErr
 	}
 
-	callbackChan := make(chan map[string]string, 1)
-	srv := startOAuthCallbackServer(addr, callbackPath, callbackChan)
-	defer srv.Close()
-
 	codeVerifier, err := client.GenerateCodeVerifier()
 	if err != nil {
 		return fmt.Errorf("failed to generate PKCE code verifier: %w", err)
@@ -171,6 +181,13 @@ func authorizeInteractively(ctx context.Context, err error, serverName, redirect
 	if err != nil {
 		return fmt.Errorf("failed to generate state: %w", err)
 	}
+
+	callbackChan := make(chan map[string]string, 1)
+	srv, err := startOAuthCallbackServer(addr, callbackPath, state, callbackChan)
+	if err != nil {
+		return fmt.Errorf("failed to start OAuth callback server: %w", err)
+	}
+	defer srv.Close()
 
 	if oauthHandler.GetClientID() == "" {
 		if err := oauthHandler.RegisterClient(ctx, "mcp-proxy ("+serverName+")"); err != nil {
@@ -186,10 +203,10 @@ func authorizeInteractively(ctx context.Context, err error, serverName, redirect
 		return fmt.Errorf("failed to build authorization URL: %w", err)
 	}
 
-	log.Printf("<%s> Opening browser for authorization: %s", serverName, authURL)
+	slog.Info("Opening browser for authorization", "server", serverName, "url", authURL)
 	openBrowser(authURL)
 
-	log.Printf("<%s> Waiting for authorization callback on %s ...", serverName, redirectURI)
+	slog.Info("Waiting for authorization callback", "server", serverName, "redirect_uri", redirectURI)
 	select {
 	case params := <-callbackChan:
 		if errMsg := params["error"]; errMsg != "" {
@@ -226,35 +243,79 @@ func parseRedirectURI(redirectURI string) (path string, addr string, err error) 
 	if err != nil {
 		return "", "", fmt.Errorf("invalid redirect URI %q: %w", redirectURI, err)
 	}
-	host := u.Host
-	if u.Port() == "" {
+	if u.Scheme != "http" {
+		return "", "", fmt.Errorf("redirect URI %q must use http", redirectURI)
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", "", fmt.Errorf("redirect URI %q cannot contain user info, query, or fragment", redirectURI)
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		return "", "", fmt.Errorf("redirect URI %q must include a host", redirectURI)
+	}
+	ip := net.ParseIP(hostname)
+	if !strings.EqualFold(hostname, "localhost") && (ip == nil || !ip.IsLoopback()) {
+		return "", "", fmt.Errorf("redirect URI %q must use localhost or a loopback IP", redirectURI)
+	}
+	port := u.Port()
+	if port == "" {
 		return "", "", fmt.Errorf("redirect URI %q must include an explicit port", redirectURI)
 	}
-	return u.Path, host, nil
+	portNumber, err := strconv.Atoi(port)
+	if err != nil || portNumber < 1 || portNumber > 65535 {
+		return "", "", fmt.Errorf("redirect URI %q contains an invalid port", redirectURI)
+	}
+	if u.Path == "" || u.Path == "/" {
+		return "", "", fmt.Errorf("redirect URI %q must include a callback path", redirectURI)
+	}
+	return u.Path, net.JoinHostPort(hostname, port), nil
 }
 
-func startOAuthCallbackServer(addr, callbackPath string, callbackChan chan<- map[string]string) *http.Server {
-	mux := http.NewServeMux()
-	srv := &http.Server{Addr: addr, Handler: mux}
+func startOAuthCallbackServer(addr, callbackPath, expectedState string, callbackChan chan<- map[string]string) (*http.Server, error) {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 
-	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != callbackPath {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Query().Get("state") != expectedState {
+			http.Error(w, "Invalid OAuth state", http.StatusBadRequest)
+			return
+		}
 		params := make(map[string]string)
 		for key, values := range r.URL.Query() {
 			if len(values) > 0 {
 				params[key] = values[0]
 			}
 		}
-		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte(`<html><body><h1>Authorization received</h1><p>You can close this window and return to the terminal.</p></body></html>`))
-		callbackChan <- params
+		select {
+		case callbackChan <- params:
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte(`<html><body><h1>Authorization received</h1><p>You can close this window and return to the terminal.</p></body></html>`))
+		default:
+			http.Error(w, "OAuth callback already received", http.StatusConflict)
+		}
 	})
+	srv := &http.Server{
+		Addr:              listener.Addr().String(),
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Printf("OAuth callback server error: %v", err)
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("OAuth callback server error", "err", err)
 		}
 	}()
-	return srv
+	return srv, nil
 }
 
 func openBrowser(rawURL string) {
@@ -270,6 +331,6 @@ func openBrowser(rawURL string) {
 		err = fmt.Errorf("unsupported platform %s", runtime.GOOS)
 	}
 	if err != nil {
-		log.Printf("Could not open browser automatically (%v); open this URL manually:\n  %s", err, rawURL)
+		slog.Warn("Could not open browser automatically; open the URL manually", "err", err, "url", rawURL)
 	}
 }

--- a/oauth_store.go
+++ b/oauth_store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,26 @@ func NewFileTokenStore(path string) *FileTokenStore {
 	return &FileTokenStore{path: path}
 }
 
+func oauthStorageName(serverName string) (string, error) {
+	if serverName == "" {
+		return "", errors.New("OAuth server name cannot be empty")
+	}
+	if serverName != "." && serverName != ".." && len(serverName) <= 128 {
+		safe := true
+		for _, r := range serverName {
+			if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '.' && r != '_' && r != '-' {
+				safe = false
+				break
+			}
+		}
+		if safe {
+			return serverName, nil
+		}
+	}
+	sum := sha256.Sum256([]byte(serverName))
+	return fmt.Sprintf("server-%x", sum[:12]), nil
+}
+
 // oauthTokenPath returns the on-disk path for a server's token file,
 // rooted under the user's config dir (~/.config/mcp-proxy/oauth on Linux).
 func oauthTokenPath(serverName string) (string, error) {
@@ -31,7 +52,11 @@ func oauthTokenPath(serverName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to determine user config dir: %w", err)
 	}
-	return filepath.Join(dir, "mcp-proxy", "oauth", serverName+".json"), nil
+	storageName, err := oauthStorageName(serverName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "mcp-proxy", "oauth", storageName+".json"), nil
 }
 
 func (s *FileTokenStore) GetToken(ctx context.Context) (*transport.Token, error) {
@@ -59,21 +84,56 @@ func (s *FileTokenStore) SaveToken(ctx context.Context, token *transport.Token) 
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if token == nil {
+		return errors.New("cannot save a nil OAuth token")
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := os.MkdirAll(filepath.Dir(s.path), 0700); err != nil {
-		return fmt.Errorf("failed to create token directory: %w", err)
+	return writePrivateJSON(s.path, token)
+}
+
+func writePrivateJSON(path string, value any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create OAuth storage directory: %w", err)
 	}
-	data, err := json.MarshalIndent(token, "", "  ")
+	if err := os.Chmod(dir, 0700); err != nil {
+		return fmt.Errorf("failed to secure OAuth storage directory: %w", err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal token: %w", err)
+		return fmt.Errorf("failed to marshal OAuth data: %w", err)
 	}
-	tmp := s.path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return fmt.Errorf("failed to write token file %s: %w", tmp, err)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary OAuth file: %w", err)
 	}
-	return os.Rename(tmp, s.path)
+	tmpPath := tmp.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0600); err != nil {
+		return fmt.Errorf("failed to secure temporary OAuth file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("failed to write temporary OAuth file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		return fmt.Errorf("failed to sync temporary OAuth file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary OAuth file: %w", err)
+	}
+	closed = true
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("failed to replace OAuth file %s: %w", path, err)
+	}
+	return nil
 }
 
 // registeredClient is what oauthClientPath persists: the client_id (and
@@ -95,7 +155,11 @@ func oauthClientPath(serverName string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to determine user config dir: %w", err)
 	}
-	return filepath.Join(dir, "mcp-proxy", "oauth", serverName+".client.json"), nil
+	storageName, err := oauthStorageName(serverName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "mcp-proxy", "oauth", storageName+".client.json"), nil
 }
 
 // loadRegisteredClient returns (clientID, clientSecret, true) if a
@@ -117,6 +181,9 @@ func loadRegisteredClient(serverName string) (string, string, bool, error) {
 	if err := json.Unmarshal(data, &rc); err != nil {
 		return "", "", false, fmt.Errorf("failed to parse client file %s: %w", path, err)
 	}
+	if rc.ClientID == "" {
+		return "", "", false, fmt.Errorf("client file %s does not contain a clientId", path)
+	}
 	return rc.ClientID, rc.ClientSecret, true, nil
 }
 
@@ -128,16 +195,8 @@ func saveRegisteredClient(serverName, clientID, clientSecret string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return fmt.Errorf("failed to create client directory: %w", err)
+	if clientID == "" {
+		return errors.New("cannot save an empty OAuth clientId")
 	}
-	data, err := json.MarshalIndent(registeredClient{ClientID: clientID, ClientSecret: clientSecret}, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal client: %w", err)
-	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return fmt.Errorf("failed to write client file %s: %w", tmp, err)
-	}
-	return os.Rename(tmp, path)
+	return writePrivateJSON(path, registeredClient{ClientID: clientID, ClientSecret: clientSecret})
 }

--- a/oauth_store_test.go
+++ b/oauth_store_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+)
+
+func TestOAuthStorageName(t *testing.T) {
+	t.Parallel()
+
+	name, err := oauthStorageName("notion-prod_1")
+	if err != nil {
+		t.Fatalf("safe storage name: %v", err)
+	}
+	if name != "notion-prod_1" {
+		t.Fatalf("safe name = %q", name)
+	}
+
+	unsafeName, err := oauthStorageName("../../credentials")
+	if err != nil {
+		t.Fatalf("unsafe storage name: %v", err)
+	}
+	if !strings.HasPrefix(unsafeName, "server-") || strings.ContainsAny(unsafeName, `/\\`) {
+		t.Fatalf("unsafe name was not safely hashed: %q", unsafeName)
+	}
+	repeated, err := oauthStorageName("../../credentials")
+	if err != nil || repeated != unsafeName {
+		t.Fatalf("storage name is not deterministic: %q, %q, %v", unsafeName, repeated, err)
+	}
+
+	if _, err := oauthStorageName(""); err == nil {
+		t.Fatal("empty server name was accepted")
+	}
+}
+
+func TestFileTokenStoreSaveAndGet(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "token.json")
+	store := NewFileTokenStore(path)
+	ctx := context.Background()
+
+	if _, err := store.GetToken(ctx); !errors.Is(err, transport.ErrNoToken) {
+		t.Fatalf("missing token error = %v, want ErrNoToken", err)
+	}
+	if err := store.SaveToken(ctx, nil); err == nil {
+		t.Fatal("saving nil token succeeded")
+	}
+
+	first := &transport.Token{AccessToken: "first", TokenType: "Bearer", RefreshToken: "refresh-1"}
+	if err := store.SaveToken(ctx, first); err != nil {
+		t.Fatalf("save first token: %v", err)
+	}
+	second := &transport.Token{AccessToken: "second", TokenType: "Bearer", RefreshToken: "refresh-2"}
+	if err := store.SaveToken(ctx, second); err != nil {
+		t.Fatalf("replace token: %v", err)
+	}
+
+	got, err := store.GetToken(ctx)
+	if err != nil {
+		t.Fatalf("get token: %v", err)
+	}
+	if got.AccessToken != second.AccessToken || got.RefreshToken != second.RefreshToken {
+		t.Fatalf("token = %#v, want %#v", got, second)
+	}
+
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat token: %v", err)
+		}
+		if permission := info.Mode().Perm(); permission != 0600 {
+			t.Fatalf("token permissions = %o, want 600", permission)
+		}
+		dirInfo, err := os.Stat(filepath.Dir(path))
+		if err != nil {
+			t.Fatalf("stat token directory: %v", err)
+		}
+		if permission := dirInfo.Mode().Perm(); permission != 0700 {
+			t.Fatalf("token directory permissions = %o, want 700", permission)
+		}
+	}
+
+	temporaryFiles, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".token.json.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob temporary files: %v", err)
+	}
+	if len(temporaryFiles) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", temporaryFiles)
+	}
+}
+
+func TestFileTokenStoreHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	store := NewFileTokenStore(filepath.Join(t.TempDir(), "token.json"))
+
+	if _, err := store.GetToken(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetToken error = %v, want context.Canceled", err)
+	}
+	if err := store.SaveToken(ctx, &transport.Token{AccessToken: "token"}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SaveToken error = %v, want context.Canceled", err)
+	}
+}

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRedirectURI(t *testing.T) {
+	t.Parallel()
+
+	valid := []struct {
+		name     string
+		raw      string
+		wantPath string
+		wantAddr string
+	}{
+		{name: "localhost", raw: "http://localhost:8090/oauth/callback", wantPath: "/oauth/callback", wantAddr: "localhost:8090"},
+		{name: "uppercase localhost", raw: "http://LOCALHOST:8090/oauth/callback", wantPath: "/oauth/callback", wantAddr: "LOCALHOST:8090"},
+		{name: "IPv4 loopback", raw: "http://127.0.0.1:9000/callback", wantPath: "/callback", wantAddr: "127.0.0.1:9000"},
+		{name: "IPv6 loopback", raw: "http://[::1]:9001/callback", wantPath: "/callback", wantAddr: "[::1]:9001"},
+	}
+	for _, tt := range valid {
+		t.Run(tt.name, func(t *testing.T) {
+			path, addr, err := parseRedirectURI(tt.raw)
+			if err != nil {
+				t.Fatalf("parse redirect URI: %v", err)
+			}
+			if path != tt.wantPath || addr != tt.wantAddr {
+				t.Fatalf("got path=%q addr=%q, want path=%q addr=%q", path, addr, tt.wantPath, tt.wantAddr)
+			}
+		})
+	}
+
+	invalid := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{name: "https", raw: "https://localhost:8090/callback", wantErr: "must use http"},
+		{name: "non-loopback", raw: "http://example.com:8090/callback", wantErr: "loopback"},
+		{name: "wildcard", raw: "http://0.0.0.0:8090/callback", wantErr: "loopback"},
+		{name: "missing port", raw: "http://localhost/callback", wantErr: "explicit port"},
+		{name: "missing path", raw: "http://localhost:8090", wantErr: "callback path"},
+		{name: "root path", raw: "http://localhost:8090/", wantErr: "callback path"},
+		{name: "query", raw: "http://localhost:8090/callback?x=1", wantErr: "query"},
+		{name: "userinfo", raw: "http://user@localhost:8090/callback", wantErr: "user info"},
+		{name: "invalid port", raw: "http://localhost:70000/callback", wantErr: "invalid port"},
+	}
+	for _, tt := range invalid {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseRedirectURI(tt.raw)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestOAuthCallbackServer(t *testing.T) {
+	t.Parallel()
+
+	callbacks := make(chan map[string]string, 1)
+	srv, err := startOAuthCallbackServer("127.0.0.1:0", "/oauth/callback", "expected-state", callbacks)
+	if err != nil {
+		t.Fatalf("start callback server: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	endpoint := "http://" + srv.Addr + "/oauth/callback"
+
+	response, err := client.Get("http://" + srv.Addr + "/other")
+	if err != nil {
+		t.Fatalf("unexpected-path callback: %v", err)
+	}
+	closeResponse(t, response)
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("unexpected-path status = %d, want %d", response.StatusCode, http.StatusNotFound)
+	}
+
+	request, err := http.NewRequest(http.MethodPost, endpoint, nil)
+	if err != nil {
+		t.Fatalf("create POST request: %v", err)
+	}
+	response, err = client.Do(request)
+	if err != nil {
+		t.Fatalf("POST callback: %v", err)
+	}
+	closeResponse(t, response)
+	if response.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status = %d, want %d", response.StatusCode, http.StatusMethodNotAllowed)
+	}
+
+	response, err = client.Get(endpoint + "?state=wrong&code=ignored")
+	if err != nil {
+		t.Fatalf("invalid-state callback: %v", err)
+	}
+	closeResponse(t, response)
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("invalid-state status = %d, want %d", response.StatusCode, http.StatusBadRequest)
+	}
+	select {
+	case callback := <-callbacks:
+		t.Fatalf("invalid state consumed callback: %#v", callback)
+	default:
+	}
+
+	query := url.Values{"state": {"expected-state"}, "code": {"test-code"}}
+	response, err = client.Get(endpoint + "?" + query.Encode())
+	if err != nil {
+		t.Fatalf("valid callback: %v", err)
+	}
+	closeResponse(t, response)
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("valid callback status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+
+	response, err = client.Get(endpoint + "?" + query.Encode())
+	if err != nil {
+		t.Fatalf("duplicate callback: %v", err)
+	}
+	closeResponse(t, response)
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate callback status = %d, want %d", response.StatusCode, http.StatusConflict)
+	}
+
+	select {
+	case callback := <-callbacks:
+		if callback["code"] != "test-code" || callback["state"] != "expected-state" {
+			t.Fatalf("callback = %#v", callback)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for callback")
+	}
+}
+
+func TestOAuthCallbackServerFailsWhenAddressInUse(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve address: %v", err)
+	}
+	defer listener.Close()
+
+	_, err = startOAuthCallbackServer(listener.Addr().String(), "/callback", "state", make(chan map[string]string, 1))
+	if err == nil {
+		t.Fatal("start callback server succeeded on an address already in use")
+	}
+}
+
+func closeResponse(t *testing.T, response *http.Response) {
+	t.Helper()
+	_, _ = io.Copy(io.Discard, response.Body)
+	if err := response.Body.Close(); err != nil {
+		t.Fatalf("close response body: %v", err)
+	}
+}


### PR DESCRIPTION
Follow-up to #70 and #67. Integrates the useful structured logging work from #58, replaces #64's load-only check with full validation, hardens OAuth callback binding/state handling and atomic credential storage, makes server startup/shutdown return errors cleanly, and upgrades jsonparser to v1.1.2 to fix CVE-2026-32285. Verified with go test ./..., go test -race ./..., go vet ./..., build, and -check-config.