### PR TITLE
fix: decode gzip responses that Go's transport leaves undecoded

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -21,6 +23,57 @@ type Client struct {
 	needManualStart bool
 	client          *client.Client
 	options         *OptionsV2
+}
+
+// gzipSafetyNetTransport ensures gzip-encoded responses are always decoded.
+// Go's stdlib transport only auto-decompresses when it added the
+// "Accept-Encoding: gzip" header itself; some upstream servers (e.g.
+// mcp.slack.com, likely via a fronting CDN) send gzip-encoded responses
+// regardless of what Accept-Encoding the client sent, which slips past
+// Go's automatic decoding and hands raw gzip bytes to the JSON decoder. This
+// wrapper decodes manually whenever Content-Encoding: gzip is still present
+// on the response, which only happens when Go didn't already handle it —
+// so it's a no-op, not a double-decode, whenever Go's automatic path works.
+type gzipSafetyNetTransport struct {
+	next http.RoundTripper
+}
+
+func (t *gzipSafetyNetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.next.RoundTrip(req)
+	if err != nil || resp == nil {
+		return resp, err
+	}
+	if !strings.EqualFold(resp.Header.Get("Content-Encoding"), "gzip") {
+		return resp, nil
+	}
+	gz, gzErr := gzip.NewReader(resp.Body)
+	if gzErr != nil {
+		return resp, gzErr
+	}
+	resp.Body = &gzipReadCloser{gz: gz, orig: resp.Body}
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
+	return resp, nil
+}
+
+type gzipReadCloser struct {
+	gz   *gzip.Reader
+	orig io.Closer
+}
+
+func (g *gzipReadCloser) Read(p []byte) (int, error) {
+	return g.gz.Read(p)
+}
+
+func (g *gzipReadCloser) Close() error {
+	_ = g.gz.Close()
+	return g.orig.Close()
+}
+
+func newHTTPClient() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	return &http.Client{Transport: &gzipSafetyNetTransport{next: tr}}
 }
 
 func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
@@ -50,7 +103,7 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 			if oErr != nil {
 				return nil, oErr
 			}
-			var options []transport.ClientOption
+			options := []transport.ClientOption{client.WithHTTPClient(newHTTPClient())}
 			if len(v.Headers) > 0 {
 				options = append(options, client.WithHeaders(v.Headers))
 			}
@@ -66,7 +119,7 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 				options:         conf.Options,
 			}, nil
 		}
-		var options []transport.ClientOption
+		options := []transport.ClientOption{client.WithHTTPClient(newHTTPClient())}
 		if len(v.Headers) > 0 {
 			options = append(options, client.WithHeaders(v.Headers))
 		}
@@ -87,7 +140,10 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 			if oErr != nil {
 				return nil, oErr
 			}
-			var options []transport.StreamableHTTPCOption
+			// WithHTTPBasicClient must come first: WithHTTPTimeout mutates
+			// whatever *http.Client is already set, so it has to run after
+			// the client is swapped in.
+			options := []transport.StreamableHTTPCOption{transport.WithHTTPBasicClient(newHTTPClient())}
 			if len(v.Headers) > 0 {
 				options = append(options, transport.WithHTTPHeaders(v.Headers))
 			}
@@ -106,7 +162,10 @@ func newMCPClient(name string, conf *MCPClientConfigV2) (*Client, error) {
 				options:         conf.Options,
 			}, nil
 		}
-		var options []transport.StreamableHTTPCOption
+		// WithHTTPBasicClient must come first: WithHTTPTimeout mutates
+		// whatever *http.Client is already set, so it has to run after the
+		// client is swapped in.
+		options := []transport.StreamableHTTPCOption{transport.WithHTTPBasicClient(newHTTPClient())}
 		if len(v.Headers) > 0 {
 			options = append(options, transport.WithHTTPHeaders(v.Headers))
 		}

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Some upstream MCP servers (e.g. mcp.slack.com) gzip their responses even when
+// the client never asked for it. Go's transport only auto-decompresses when it
+// added "Accept-Encoding: gzip" itself, so those responses reach the JSON
+// decoder as raw gzip bytes. newHTTPClient installs a safety net for that.
+func TestGzipSafetyNetDecodesUnrequestedGzip(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"jsonrpc":"2.0","id":1,"result":{}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "application/json")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		_, _ = io.WriteString(gz, body)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	// Setting Accept-Encoding explicitly is what disables Go's automatic
+	// decompression, reproducing the case the safety net exists for.
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	resp, err := newHTTPClient().Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body not decoded\n got: %q\nwant: %q", got, body)
+	}
+	if enc := resp.Header.Get("Content-Encoding"); enc != "" {
+		t.Fatalf("Content-Encoding should be cleared after decoding, got %q", enc)
+	}
+}
+
+// When Go's own decompression already ran, the safety net must stay out of the
+// way rather than attempt a second decode.
+func TestGzipSafetyNetDoesNotDoubleDecode(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"jsonrpc":"2.0","id":2,"result":{}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept-Encoding") == "" {
+			t.Errorf("expected Go to add Accept-Encoding: gzip")
+		}
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Type", "application/json")
+		gz := gzip.NewWriter(w)
+		defer gz.Close()
+		_, _ = io.WriteString(gz, body)
+	}))
+	defer srv.Close()
+
+	resp, err := newHTTPClient().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body corrupted\n got: %q\nwant: %q", got, body)
+	}
+}
+
+// Uncompressed responses must pass through untouched.
+func TestGzipSafetyNetPassesThroughPlainResponses(t *testing.T) {
+	t.Parallel()
+
+	const body = `{"jsonrpc":"2.0","id":3,"result":{}}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	resp, err := newHTTPClient().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body altered\n got: %q\nwant: %q", got, body)
+	}
+}


### PR DESCRIPTION
## Problem

Calls to some downstream MCP servers fail with:

```
invalid character '\x1f' looking for beginning of value
```

`0x1f` is the gzip magic byte — raw gzip bytes are reaching the JSON decoder.

Go's stdlib transport only auto-decompresses a response when it added the `Accept-Encoding: gzip` header *itself*. When something upstream in the chain sets that header explicitly, Go steps back and hands the compressed body through untouched. Some servers (`mcp.slack.com`, apparently via a fronting CDN) send gzip-encoded responses regardless of what the client negotiated, so the body lands in the JSON decoder still compressed.

## Fix

Wrap the outbound transport with a small safety net: if a response still carries `Content-Encoding: gzip` by the time it reaches us, Go didn't handle it, so decode manually.

When Go's automatic path *does* work, it has already stripped the header, so the wrapper is a no-op — there's no double-decode risk. Uncompressed responses pass through untouched.

Disabling compression negotiation outright was tried first and is the wrong lever — it makes the problem worse rather than better.

## Verification

- Three regression tests covering all three paths (unrequested gzip, Go-decoded gzip, plain). The first fails with the raw `\x1f\x8b...` body if the wrapper is removed.
- Verified live through the proxy against Slack (previously ~100% reproducible) and Datadog (previously intermittent).