### PR TITLE
OAuth route lifecycle: restart-free credential pickup (proposed series)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Build, format, test
+
+```bash
+make build    # CGO_ENABLED=0 build to ./build/
+make format   # go fix/fmt/vet/test/tidy, golangci-lint, nilaway
+```
+
+Run `make format` before proposing a change — it covers `go vet`,
+`go test ./...`, and lint/nilaway in one step. Keep builds `CGO_ENABLED=0`
+(already the default in the Makefile).
+
+## Docs
+
+Start with whichever of these matches the task:
+
+- [docs/USAGE.md](docs/USAGE.md) — CLI flags, endpoints, health checks, auth,
+  running `-authorize`.
+- [docs/CONFIGURATION.md](docs/CONFIGURATION.md) — `config.json` schema,
+  including the `oauth` block.
+- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) — running the proxy as a service.
+- [docs/OAUTH_LIFECYCLE.md](docs/OAUTH_LIFECYCLE.md) — design notes on how
+  OAuth-authorized routes are mounted and refreshed, the current
+  restart-to-reauthorize gap, and the planned incremental fix. Read this
+  before touching route mounting, token storage/refresh
+  (`oauth.go`, `oauth_store.go`), or the startup connect loop (`http.go`).
+
+## Working on this repo
+
+- Small, independently-reviewable PRs over one large change
+- See relevant docs when working on a section (e.g. OAUTH_LIFECYCLE when doing anything auth related)

--- a/docs/OAUTH_LIFECYCLE.md
+++ b/docs/OAUTH_LIFECYCLE.md
@@ -62,6 +62,17 @@ lost write race, no leaked connections from repeated retries.
 4. **Disk is the sole source of truth, on every request, always.** No
    in-process cache of secret values at any point in this design.
 
+Point 2's local check gates the credential case, not liveness: a server
+with a present-but-bad credential (revoked token, unreachable upstream)
+still attempts a real connect on every request that reaches it, coalesced
+per-server by a single-flight lock (implemented in `route.go`'s
+`serverRoute`) so concurrent requests share one attempt rather than each
+paying for their own. There's deliberately no backoff on repeated failures
+yet - a persistently broken server gets retried on every request that
+reaches it, not just the first. Acceptable for now on the same reasoning as
+the [known limitation](#known-limitation-concurrent-refresh-token-use)
+below: add one if it turns out to matter in practice, don't pre-build it.
+
 ## Explicitly rejected approaches
 
 Worth recording so these don't get re-proposed and re-litigated later:

--- a/docs/OAUTH_LIFECYCLE.md
+++ b/docs/OAUTH_LIFECYCLE.md
@@ -1,0 +1,145 @@
+# OAuth & route lifecycle: design notes
+
+This document describes how OAuth-authorized routes behave today, the gap
+that causes the [known 404 failure mode](USAGE.md#oauth-authorizing-a-downstream-server),
+and the target design for closing it. It's written as a reference for anyone
+(human or agent) picking up related work, and as a map for the stack of
+incremental changes that implement it — see [Delivery plan](#delivery-plan).
+
+## Current behavior
+
+- Every configured server is connected to exactly once, at daemon startup.
+  Only on a successful connect does its HTTP route get registered; a server
+  that fails to connect (most commonly: an `oauth`-configured server with no
+  valid token yet) never gets a route at all, so requests to it 404 rather
+  than failing with anything that explains why.
+- `-authorize` runs as a separate, one-shot process. It has no way to signal
+  a running daemon — no pidfile, no socket, no reload signal — so the only
+  way for a newly-authorized server to start working is a full restart
+  (documented today in [USAGE.md](USAGE.md#oauth-authorizing-a-downstream-server)).
+- For a server whose route *is* already mounted, token rotation already
+  works with no daemon involvement: the token store does a fresh disk read
+  on every outgoing request, with no in-memory cache to go stale. This part
+  isn't broken and this design doesn't change it.
+
+## Problem statement
+
+Restart-to-pick-up-authorization is the actual operational pain: running
+`-authorize` should be enough to make a server work, without an operator
+remembering (or automating) a restart afterward. And a 404 on a
+not-yet-authorized route reads as "this route doesn't exist," not "this
+route exists but needs authorization" — the failure should say what's
+actually wrong.
+
+The goal is closing both gaps without introducing new failure modes —
+no crash loops on ordinary token refresh, no corrupted token files from a
+lost write race, no leaked connections from repeated retries.
+
+## Target design
+
+1. **Every configured server's route is mounted at startup, unconditionally.**
+   Connect failure no longer means "no route" — it means "route exists,
+   currently failing," which is a state a request can report clearly.
+2. **No credential on disk yet → fail immediately, locally, with no network
+   call.** This is a plain disk check (the same one `-auth-status` already
+   does), not an attempt to connect. It's what makes retrying on every
+   request to a still-unauthorized server free instead of expensive: there's
+   nothing to open, so there's nothing to tear down.
+3. **A credential exists:**
+   - **3a.** Access token still valid → use it. This is the existing,
+     already-correct happy path — no change.
+   - **3b.** Access token invalid → refresh it. No in-process lock around
+     this — see [Known limitation](#known-limitation-concurrent-refresh-token-use)
+     below for why not. The one rule that's load-bearing here: a failed
+     refresh must never write anything to disk; only a successful token
+     exchange writes. That's what makes a race between two refresh
+     attempts (the daemon's own, a separately-run `-authorize`, or two
+     concurrent requests both finding an expired token) safe without any
+     coordination at all: whichever attempt actually succeeds is the only
+     write that lands, and a losing attempt (e.g. `invalid_grant` from an
+     already-rotated refresh token) simply produces no write to conflict
+     with it. The loser just fails its own request.
+4. **Disk is the sole source of truth, on every request, always.** No
+   in-process cache of secret values at any point in this design.
+
+## Explicitly rejected approaches
+
+Worth recording so these don't get re-proposed and re-litigated later:
+
+- **fsnotify / filesystem watching** to detect credential changes —
+  unnecessary once every request already re-reads fresh from disk on demand
+  (point 4). Also would have added a dependency and per-platform watcher
+  semantics (inotify/kqueue/ReadDirectoryChangesW behave differently enough
+  around debouncing and directory-vs-file watches to be worth avoiding) for
+  no behavioral gain over "just read it when you need it."
+- **Content-hash or mtime tracking** to distinguish the daemon's own writes
+  from an external process's writes — solves a problem that doesn't exist
+  once nothing reacts to file-change *events* in the first place; only
+  point 3b's write-on-success-only rule matters, and that's enforced at the
+  point of writing, not by inspecting the file afterward.
+- **An in-memory token cache** — the reads involved are small, infrequent
+  files; OS page caching already makes repeat reads cheap, and adding an
+  explicit cache only reintroduces the invalidation problem this design
+  avoids by not having one.
+- **Crash-on-file-change as a reload mechanism** — a hedge against
+  staleness that a no-cache design has no need for.
+- **`config.json` / environment-variable hot-reload** — explicitly out of
+  scope. Config changes require a restart; that's an accepted constraint,
+  not a gap this document is trying to close.
+
+## Known limitation: concurrent refresh-token use
+
+Checked against `mcp-go` v0.56.0's actual source (`client/transport/oauth.go`):
+`OAuthHandler` has no guard around token refresh. Its only `sync.Once`
+dedupes OAuth server-metadata discovery, not the refresh-token grant;
+`getValidToken`/`refreshToken` take no lock at all. Two concurrent requests
+that both find the access token expired will independently POST to the
+token endpoint with the same `refresh_token`. Against a provider that
+rotates refresh tokens on use, the losing POST comes back `invalid_grant`
+and that caller's request fails with a spurious "needs re-authorization" —
+even though the other request's refresh just saved a good token a moment
+earlier (`mcp-go`'s own test, `TestOAuthHandler_RefreshToken_SingleUseRefreshToken`,
+demonstrates this exact response shape).
+
+This can't be fixed from mcp-proxy's own code without either forking
+`mcp-go` or serializing an entire server's traffic (not just the refresh):
+the automatic per-request refresh path is invoked transparently, internally,
+by the transport, and the only surface mcp-proxy controls — the injected
+`TokenStore` — sits on the wrong side of the race (it's read *before* the
+decision to refresh, and written *after* the network call, never in a
+position to guard the network call itself). Making `TokenStore.GetToken`
+proactively refresh so it never hands back an expired token was considered
+and rejected — it would mean reimplementing a meaningful chunk of
+`refreshToken`'s already-correct, already-tested logic inside mcp-proxy
+just to wrap a lock around it.
+
+**Decision: accept this as-is, not planned work.** Concurrent requests to
+the same downstream service are rare in practice, and callers (MCP clients,
+agent tool-call loops) generally retry a failed call on their own. The
+existing write discipline (§3b: only a successful refresh ever writes)
+already guarantees the failure is contained — the winner's token lands
+correctly, the loser just fails its one request, nothing gets corrupted or
+lost. The right long-term fix is a small upstream `mcp-go` change (a mutex
+or `singleflight.Group` around `getValidToken`/`refreshToken` — it'd affect
+every consumer of its OAuth support, not just this proxy), but it isn't
+blocking anything in the delivery plan below and isn't being built here.
+
+## Delivery plan
+
+Landing as a stack of small, independently reviewable changes rather than
+one large rewrite:
+
+1. This document.
+2. Extract the per-server connect/mount logic used at startup into a
+   reusable function, with no behavior change — groundwork for calling it
+   more than once.
+3. Always-mount + fail-fast-locally for servers with no credential yet
+   (design points 1–2). User-visible improvement on its own: a clear error
+   instead of a bare 404, even before anything reloads without a restart.
+4. Lazy connect-on-request for a not-yet-ready route, guarded by a
+   per-server single-flight lock (design point 3a, still restart-free for
+   the case that matters most: point 4's "run `-authorize` and it just
+   works").
+
+Refresh-token concurrency (design point 3b) is not a planned item — see
+[Known limitation](#known-limitation-concurrent-refresh-token-use) above.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -78,9 +78,13 @@ it to disk. Run it interactively, in a session with a real browser -
 never from an unattended service/container, since it requires you to log
 in and approve access.
 
-Once authorized, (re)start the daemon. A server's HTTP route is only
-mounted on a successful connect at startup, so if the daemon was already
-running when you authorized, restart it now - the new token won't be
-picked up otherwise. After that, tokens refresh automatically as they
-expire with no further restarts needed. Re-run `-authorize` only if the
-server reports the token is no longer valid (e.g. access was revoked).
+Once authorized, (re)start the daemon. A server's route is always mounted,
+but if it had no valid credential at startup it responds `503 Service
+Unavailable` (with the exact `-authorize` command to run) instead of
+proxying - so if the daemon was already running when you authorized,
+restart it now for the new token to take effect. Restart-free pickup of a
+freshly-run `-authorize` is planned but not yet implemented; see
+[OAUTH_LIFECYCLE.md](OAUTH_LIFECYCLE.md). After a route is working, tokens
+refresh automatically as they expire with no further restarts needed.
+Re-run `-authorize` only if the server reports the token is no longer
+valid (e.g. access was revoked).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -78,13 +78,12 @@ it to disk. Run it interactively, in a session with a real browser -
 never from an unattended service/container, since it requires you to log
 in and approve access.
 
-Once authorized, (re)start the daemon. A server's route is always mounted,
-but if it had no valid credential at startup it responds `503 Service
-Unavailable` (with the exact `-authorize` command to run) instead of
-proxying - so if the daemon was already running when you authorized,
-restart it now for the new token to take effect. Restart-free pickup of a
-freshly-run `-authorize` is planned but not yet implemented; see
-[OAUTH_LIFECYCLE.md](OAUTH_LIFECYCLE.md). After a route is working, tokens
-refresh automatically as they expire with no further restarts needed.
-Re-run `-authorize` only if the server reports the token is no longer
-valid (e.g. access was revoked).
+No restart needed. A server's route is always mounted; if it had no valid
+credential at startup it responds `503 Service Unavailable` (with the
+exact `-authorize` command to run) instead of proxying, and the *next*
+request against that route - after running `-authorize` - retries the
+connection and starts proxying on success, with no restart and no re-mount
+(see [OAUTH_LIFECYCLE.md](OAUTH_LIFECYCLE.md)). After a route is working,
+tokens refresh automatically as they expire, same as always. Re-run
+`-authorize` only if the server reports the token is no longer valid (e.g.
+access was revoked).

--- a/http.go
+++ b/http.go
@@ -106,6 +106,42 @@ func healthHandler(config *Config) http.HandlerFunc {
 	}
 }
 
+// connectAndMount runs a single server's connect/initialize sequence
+// against an already-built client and server pair and, on success, wires
+// its tools/prompts/resources into srv.mcpServer and mounts its HTTP route
+// on httpMux. It's the per-server body of the startup connect loop, factored
+// out so the same sequence can be re-run later for a single server (e.g.
+// after `-authorize` provides a credential that wasn't there at startup)
+// without repeating the whole loop or requiring a restart.
+func connectAndMount(ctx context.Context, name string, clientConfig *MCPClientConfigV2, info mcp.Implementation, mcpClient *Client, srv *Server, baseURL *url.URL, httpMux *http.ServeMux) error {
+	slog.Info("Connecting", "client", name)
+	addErr := mcpClient.addToMCPServer(ctx, info, srv.mcpServer)
+	if addErr != nil {
+		slog.Error("Failed to add client to server", "client", name, "err", addErr)
+		return addErr
+	}
+	slog.Info("Connected", "client", name)
+
+	middlewares := make([]MiddlewareFunc, 0)
+	middlewares = append(middlewares, recoverMiddleware(name))
+	if clientConfig.Options.LogEnabled.OrElse(false) {
+		middlewares = append(middlewares, loggerMiddleware(name))
+	}
+	if len(clientConfig.Options.AuthTokens) > 0 {
+		middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
+	}
+	mcpRoute := path.Join(baseURL.Path, name)
+	if !strings.HasPrefix(mcpRoute, "/") {
+		mcpRoute = "/" + mcpRoute
+	}
+	if !strings.HasSuffix(mcpRoute, "/") {
+		mcpRoute += "/"
+	}
+	slog.Info("Handling requests", "client", name, "route", mcpRoute)
+	httpMux.Handle(mcpRoute, chainMiddleware(srv.handler, middlewares...))
+	return nil
+}
+
 func startHTTPServer(config *Config) error {
 	baseURL, uErr := url.Parse(config.McpProxy.BaseURL)
 	if uErr != nil {
@@ -146,34 +182,10 @@ func startHTTPServer(config *Config) error {
 		}
 		clients[name] = mcpClient
 		errorGroup.Go(func() error {
-			slog.Info("Connecting", "client", name)
-			addErr := mcpClient.addToMCPServer(ctx, info, server.mcpServer)
-			if addErr != nil {
-				slog.Error("Failed to add client to server", "client", name, "err", addErr)
-				if clientConfig.Options.PanicIfInvalid.OrElse(false) {
-					return addErr
-				}
-				return nil
+			connErr := connectAndMount(ctx, name, clientConfig, info, mcpClient, server, baseURL, httpMux)
+			if connErr != nil && clientConfig.Options.PanicIfInvalid.OrElse(false) {
+				return connErr
 			}
-			slog.Info("Connected", "client", name)
-
-			middlewares := make([]MiddlewareFunc, 0)
-			middlewares = append(middlewares, recoverMiddleware(name))
-			if clientConfig.Options.LogEnabled.OrElse(false) {
-				middlewares = append(middlewares, loggerMiddleware(name))
-			}
-			if len(clientConfig.Options.AuthTokens) > 0 {
-				middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
-			}
-			mcpRoute := path.Join(baseURL.Path, name)
-			if !strings.HasPrefix(mcpRoute, "/") {
-				mcpRoute = "/" + mcpRoute
-			}
-			if !strings.HasSuffix(mcpRoute, "/") {
-				mcpRoute += "/"
-			}
-			slog.Info("Handling requests", "client", name, "route", mcpRoute)
-			httpMux.Handle(mcpRoute, chainMiddleware(server.handler, middlewares...))
 			return nil
 		})
 	}

--- a/http.go
+++ b/http.go
@@ -10,8 +10,8 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -106,43 +106,20 @@ func healthHandler(config *Config) http.HandlerFunc {
 	}
 }
 
-// routeForServer returns the HTTP path a named server's route is (or will
-// be) mounted at under baseURL, always with a trailing slash so it matches
-// as a subtree.
-func routeForServer(baseURL *url.URL, name string) string {
-	mcpRoute := path.Join(baseURL.Path, name)
-	if !strings.HasPrefix(mcpRoute, "/") {
-		mcpRoute = "/" + mcpRoute
-	}
-	if !strings.HasSuffix(mcpRoute, "/") {
-		mcpRoute += "/"
-	}
-	return mcpRoute
-}
-
-// notReadyHandler responds to every request with a clear, immediate error
-// instead of a bare 404, for a server whose most recent connect attempt
-// failed (most commonly: no valid OAuth token yet - see err, which for that
-// case already carries the exact `-authorize` command to run, courtesy of
-// oauthAwareError). It never touches the network: the failure reason was
-// captured once, at connect time, not looked up per request.
-func notReadyHandler(name string, err error) http.Handler {
-	message := fmt.Sprintf("mcp-proxy: server %q is not available: %v\n", name, err)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, message, http.StatusServiceUnavailable)
-	})
-}
-
 // connectAndMount runs a single server's connect/initialize sequence
 // against an already-built client and server pair and mounts its HTTP
 // route on httpMux either way: on success, the real proxying handler; on
-// failure, notReadyHandler, so the route always exists and a request
-// against it always gets a clear answer instead of a bare 404. It's the
-// per-server body of the startup connect loop, factored out so the same
-// sequence can be re-run later for a single server (e.g. after
-// `-authorize` provides a credential that wasn't there at startup) without
-// repeating the whole loop or requiring a restart.
-func connectAndMount(ctx context.Context, name string, clientConfig *MCPClientConfigV2, info mcp.Implementation, mcpClient *Client, srv *Server, baseURL *url.URL, httpMux *http.ServeMux) error {
+// failure, a serverRoute that retries lazily on each subsequent request
+// (see docs/OAUTH_LIFECYCLE.md and route.go) instead of requiring a
+// restart. The route always exists either way, so a request against it
+// always gets a clear answer instead of a bare 404. It's the per-server
+// body of the startup connect loop, factored out so the same sequence can
+// be re-run later for a single server without repeating the whole loop.
+//
+// Returns the serverRoute mounted on failure (nil on success) so the
+// caller can track it and, at shutdown, close its client if it ever
+// connects.
+func connectAndMount(ctx context.Context, name string, clientConfig *MCPClientConfigV2, proxyConfig *MCPProxyConfigV2, info mcp.Implementation, mcpClient *Client, srv *Server, baseURL *url.URL, httpMux *http.ServeMux) (*serverRoute, error) {
 	mcpRoute := routeForServer(baseURL, name)
 
 	slog.Info("Connecting", "client", name)
@@ -150,22 +127,14 @@ func connectAndMount(ctx context.Context, name string, clientConfig *MCPClientCo
 	if addErr != nil {
 		slog.Error("Failed to add client to server", "client", name, "err", addErr)
 		slog.Info("Mounting not-ready route", "client", name, "route", mcpRoute)
-		httpMux.Handle(mcpRoute, notReadyHandler(name, addErr))
-		return addErr
+		route := newServerRoute(ctx, name, clientConfig, proxyConfig, info)
+		httpMux.Handle(mcpRoute, route)
+		return route, addErr
 	}
 	slog.Info("Connected", "client", name)
-
-	middlewares := make([]MiddlewareFunc, 0)
-	middlewares = append(middlewares, recoverMiddleware(name))
-	if clientConfig.Options.LogEnabled.OrElse(false) {
-		middlewares = append(middlewares, loggerMiddleware(name))
-	}
-	if len(clientConfig.Options.AuthTokens) > 0 {
-		middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
-	}
 	slog.Info("Handling requests", "client", name, "route", mcpRoute)
-	httpMux.Handle(mcpRoute, chainMiddleware(srv.handler, middlewares...))
-	return nil
+	httpMux.Handle(mcpRoute, wrapHandler(name, clientConfig, srv))
+	return nil, nil
 }
 
 func startHTTPServer(config *Config) error {
@@ -187,6 +156,8 @@ func startHTTPServer(config *Config) error {
 		Name: config.McpProxy.Name,
 	}
 	clients := make(map[string]*Client, len(config.McpServers))
+	var routesMu sync.Mutex
+	var routes []*serverRoute
 
 	// Unauthenticated health endpoints for liveness/readiness probes.
 	health := healthHandler(config)
@@ -208,7 +179,12 @@ func startHTTPServer(config *Config) error {
 		}
 		clients[name] = mcpClient
 		errorGroup.Go(func() error {
-			connErr := connectAndMount(ctx, name, clientConfig, info, mcpClient, server, baseURL, httpMux)
+			route, connErr := connectAndMount(ctx, name, clientConfig, config.McpProxy, info, mcpClient, server, baseURL, httpMux)
+			if route != nil {
+				routesMu.Lock()
+				routes = append(routes, route)
+				routesMu.Unlock()
+			}
 			if connErr != nil && clientConfig.Options.PanicIfInvalid.OrElse(false) {
 				return connErr
 			}
@@ -247,6 +223,11 @@ func startHTTPServer(config *Config) error {
 			slog.Info("Shutting down", "client", name)
 			if err := client.Close(); err != nil {
 				shutdownErrors = append(shutdownErrors, fmt.Errorf("close client %q: %w", name, err))
+			}
+		}
+		for _, route := range routes {
+			if err := route.Close(); err != nil {
+				shutdownErrors = append(shutdownErrors, fmt.Errorf("close client %q: %w", route.name, err))
 			}
 		}
 		return errors.Join(shutdownErrors...)

--- a/http.go
+++ b/http.go
@@ -106,18 +106,51 @@ func healthHandler(config *Config) http.HandlerFunc {
 	}
 }
 
+// routeForServer returns the HTTP path a named server's route is (or will
+// be) mounted at under baseURL, always with a trailing slash so it matches
+// as a subtree.
+func routeForServer(baseURL *url.URL, name string) string {
+	mcpRoute := path.Join(baseURL.Path, name)
+	if !strings.HasPrefix(mcpRoute, "/") {
+		mcpRoute = "/" + mcpRoute
+	}
+	if !strings.HasSuffix(mcpRoute, "/") {
+		mcpRoute += "/"
+	}
+	return mcpRoute
+}
+
+// notReadyHandler responds to every request with a clear, immediate error
+// instead of a bare 404, for a server whose most recent connect attempt
+// failed (most commonly: no valid OAuth token yet - see err, which for that
+// case already carries the exact `-authorize` command to run, courtesy of
+// oauthAwareError). It never touches the network: the failure reason was
+// captured once, at connect time, not looked up per request.
+func notReadyHandler(name string, err error) http.Handler {
+	message := fmt.Sprintf("mcp-proxy: server %q is not available: %v\n", name, err)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, message, http.StatusServiceUnavailable)
+	})
+}
+
 // connectAndMount runs a single server's connect/initialize sequence
-// against an already-built client and server pair and, on success, wires
-// its tools/prompts/resources into srv.mcpServer and mounts its HTTP route
-// on httpMux. It's the per-server body of the startup connect loop, factored
-// out so the same sequence can be re-run later for a single server (e.g.
-// after `-authorize` provides a credential that wasn't there at startup)
-// without repeating the whole loop or requiring a restart.
+// against an already-built client and server pair and mounts its HTTP
+// route on httpMux either way: on success, the real proxying handler; on
+// failure, notReadyHandler, so the route always exists and a request
+// against it always gets a clear answer instead of a bare 404. It's the
+// per-server body of the startup connect loop, factored out so the same
+// sequence can be re-run later for a single server (e.g. after
+// `-authorize` provides a credential that wasn't there at startup) without
+// repeating the whole loop or requiring a restart.
 func connectAndMount(ctx context.Context, name string, clientConfig *MCPClientConfigV2, info mcp.Implementation, mcpClient *Client, srv *Server, baseURL *url.URL, httpMux *http.ServeMux) error {
+	mcpRoute := routeForServer(baseURL, name)
+
 	slog.Info("Connecting", "client", name)
 	addErr := mcpClient.addToMCPServer(ctx, info, srv.mcpServer)
 	if addErr != nil {
 		slog.Error("Failed to add client to server", "client", name, "err", addErr)
+		slog.Info("Mounting not-ready route", "client", name, "route", mcpRoute)
+		httpMux.Handle(mcpRoute, notReadyHandler(name, addErr))
 		return addErr
 	}
 	slog.Info("Connected", "client", name)
@@ -129,13 +162,6 @@ func connectAndMount(ctx context.Context, name string, clientConfig *MCPClientCo
 	}
 	if len(clientConfig.Options.AuthTokens) > 0 {
 		middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
-	}
-	mcpRoute := path.Join(baseURL.Path, name)
-	if !strings.HasPrefix(mcpRoute, "/") {
-		mcpRoute = "/" + mcpRoute
-	}
-	if !strings.HasSuffix(mcpRoute, "/") {
-		mcpRoute += "/"
 	}
 	slog.Info("Handling requests", "client", name, "route", mcpRoute)
 	httpMux.Handle(mcpRoute, chainMiddleware(srv.handler, middlewares...))

--- a/http_test.go
+++ b/http_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -59,10 +63,11 @@ func TestConnectAndMountMountsNotReadyRouteOnFailure(t *testing.T) {
 	}
 	defer mcpClient.Close()
 
-	srv, err := newMCPServer("broken", &MCPProxyConfigV2{
+	proxyConfig := &MCPProxyConfigV2{
 		Type:    MCPServerTypeStreamable,
 		Version: "test",
-	}, clientConfig)
+	}
+	srv, err := newMCPServer("broken", proxyConfig, clientConfig)
 	if err != nil {
 		t.Fatalf("newMCPServer: %v", err)
 	}
@@ -73,9 +78,12 @@ func TestConnectAndMountMountsNotReadyRouteOnFailure(t *testing.T) {
 	}
 	httpMux := http.NewServeMux()
 
-	connErr := connectAndMount(t.Context(), "broken", clientConfig, mcp.Implementation{Name: "test"}, mcpClient, srv, baseURL, httpMux)
+	route, connErr := connectAndMount(t.Context(), "broken", clientConfig, proxyConfig, mcp.Implementation{Name: "test"}, mcpClient, srv, baseURL, httpMux)
 	if connErr == nil {
 		t.Fatal("connectAndMount error = nil, want error from failed connect")
+	}
+	if route == nil {
+		t.Fatal("connectAndMount route = nil, want a serverRoute mounted for the failed server")
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/broken/", nil)
@@ -87,5 +95,193 @@ func TestConnectAndMountMountsNotReadyRouteOnFailure(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "broken") {
 		t.Fatalf("body = %q, want it to mention the server name", rec.Body.String())
+	}
+}
+
+// The headline promise of docs/OAUTH_LIFECYCLE.md: once a server that
+// failed to connect at startup becomes reachable, the very next request
+// against its already-mounted route succeeds - no restart, no re-mount.
+func TestServerRouteRecoversOnNextRequestOnceUpstreamWorks(t *testing.T) {
+	t.Parallel()
+
+	var authorized atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !authorized.Load() {
+			http.Error(w, "not authorized yet", http.StatusInternalServerError)
+			return
+		}
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		result := map[string]any{}
+		if request.Method == string(mcp.MethodInitialize) {
+			result = map[string]any{
+				"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+				"capabilities":    map[string]any{},
+				"serverInfo":      map[string]string{"name": "test", "version": "test"},
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result":  result,
+		})
+	}))
+	defer upstream.Close()
+
+	clientConfig := &MCPClientConfigV2{
+		TransportType: MCPClientTypeStreamable,
+		URL:           upstream.URL,
+		Options:       &OptionsV2{},
+	}
+	proxyConfig := &MCPProxyConfigV2{
+		Type:    MCPServerTypeStreamable,
+		Version: "test",
+	}
+	baseURL, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	httpMux := http.NewServeMux()
+
+	mcpClient, err := newMCPClient("retry", clientConfig)
+	if err != nil {
+		t.Fatalf("newMCPClient: %v", err)
+	}
+	defer mcpClient.Close()
+	srv, err := newMCPServer("retry", proxyConfig, clientConfig)
+	if err != nil {
+		t.Fatalf("newMCPServer: %v", err)
+	}
+
+	route, connErr := connectAndMount(t.Context(), "retry", clientConfig, proxyConfig, mcp.Implementation{Name: "test"}, mcpClient, srv, baseURL, httpMux)
+	if connErr == nil {
+		t.Fatal("connectAndMount error = nil, want error before authorization")
+	}
+	if route == nil {
+		t.Fatal("connectAndMount route = nil, want a serverRoute mounted for the failed server")
+	}
+
+	rec := httptest.NewRecorder()
+	httpMux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/retry/", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("before authorization: status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+
+	// Simulate running `-authorize` in a separate process: the credential
+	// the client uses now works. Nothing about the mounted route changes -
+	// no re-mount, no restart.
+	authorized.Store(true)
+
+	// POST, not GET: a bare GET against the real StreamableHTTPServer opens
+	// a long-lived SSE notification stream by design (streamable-http's
+	// subscribe verb) and would hang the test waiting for it to close.
+	// POST is the normal bounded request/response path.
+	rec = httptest.NewRecorder()
+	httpMux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/retry/", strings.NewReader("{}")))
+	if rec.Code == http.StatusServiceUnavailable {
+		t.Fatalf("after authorization: status = %d, want the route to have recovered, body: %s", rec.Code, rec.Body.String())
+	}
+
+	route.mu.RLock()
+	ready := route.ready
+	route.mu.RUnlock()
+	if ready == nil {
+		t.Fatal("route.ready is nil, want the retry to have populated it")
+	}
+}
+
+// The stampede guard: a burst of concurrent requests against a not-yet-ready
+// route must coalesce into a single connect attempt, not one per request -
+// see docs/OAUTH_LIFECYCLE.md's discussion of why that matters (wasted
+// duplicate work at best, tripping single-use refresh-token rotation at an
+// upstream OAuth provider at worst).
+func TestServerRouteCoalescesConcurrentConnectAttempts(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		result := map[string]any{}
+		if request.Method == string(mcp.MethodInitialize) {
+			// Block here so every concurrent goroutine below is guaranteed
+			// to have reached (and be waiting on) this one in-flight
+			// attempt before any response lands - without this, a fast
+			// round trip could complete before all goroutines even start,
+			// making the test pass by luck even if coalescing were broken.
+			attempts.Add(1)
+			<-release
+			result = map[string]any{
+				"protocolVersion": mcp.LATEST_PROTOCOL_VERSION,
+				"capabilities":    map[string]any{},
+				"serverInfo":      map[string]string{"name": "test", "version": "test"},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request.ID,
+			"result":  result,
+		})
+	}))
+	defer upstream.Close()
+
+	clientConfig := &MCPClientConfigV2{
+		TransportType: MCPClientTypeStreamable,
+		URL:           upstream.URL,
+		Options:       &OptionsV2{},
+	}
+	proxyConfig := &MCPProxyConfigV2{
+		Type:    MCPServerTypeStreamable,
+		Version: "test",
+	}
+	baseURL, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	httpMux := http.NewServeMux()
+	route := newServerRoute(t.Context(), "concurrent", clientConfig, proxyConfig, mcp.Implementation{Name: "test"})
+	httpMux.Handle(routeForServer(baseURL, "concurrent"), route)
+
+	const n = 20
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	codes := make([]int, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			rec := httptest.NewRecorder()
+			httpMux.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/concurrent/", strings.NewReader("{}")))
+			codes[i] = rec.Code
+		}(i)
+	}
+	close(start)
+	time.Sleep(50 * time.Millisecond) // let every goroutine reach the block above
+	close(release)
+	wg.Wait()
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("upstream Initialize hits = %d, want exactly 1 (concurrent requests should coalesce into a single connect attempt)", got)
+	}
+	for i, code := range codes {
+		if code == http.StatusServiceUnavailable {
+			t.Errorf("request %d: status = %d, want the coalesced connect's result, not a not-ready response", i, code)
+		}
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 func TestStartHTTPServerReturnsListenError(t *testing.T) {
@@ -30,5 +35,57 @@ func TestStartHTTPServerReturnsListenError(t *testing.T) {
 	err = startHTTPServer(config)
 	if err == nil || !strings.Contains(err.Error(), "HTTP server failed") {
 		t.Fatalf("startHTTPServer error = %v, want listen failure", err)
+	}
+}
+
+// A server that fails to connect still gets its route mounted, responding
+// with a clear 503 instead of a bare 404 - see docs/OAUTH_LIFECYCLE.md.
+func TestConnectAndMountMountsNotReadyRouteOnFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	clientConfig := &MCPClientConfigV2{
+		TransportType: MCPClientTypeStreamable,
+		URL:           upstream.URL,
+		Options:       &OptionsV2{},
+	}
+	mcpClient, err := newMCPClient("broken", clientConfig)
+	if err != nil {
+		t.Fatalf("newMCPClient: %v", err)
+	}
+	defer mcpClient.Close()
+
+	srv, err := newMCPServer("broken", &MCPProxyConfigV2{
+		Type:    MCPServerTypeStreamable,
+		Version: "test",
+	}, clientConfig)
+	if err != nil {
+		t.Fatalf("newMCPServer: %v", err)
+	}
+
+	baseURL, err := url.Parse("http://example.com")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	httpMux := http.NewServeMux()
+
+	connErr := connectAndMount(t.Context(), "broken", clientConfig, mcp.Implementation{Name: "test"}, mcpClient, srv, baseURL, httpMux)
+	if connErr == nil {
+		t.Fatal("connectAndMount error = nil, want error from failed connect")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/broken/", nil)
+	rec := httptest.NewRecorder()
+	httpMux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(rec.Body.String(), "broken") {
+		t.Fatalf("body = %q, want it to mention the server name", rec.Body.String())
 	}
 }

--- a/route.go
+++ b/route.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"golang.org/x/sync/singleflight"
+)
+
+// routeForServer returns the HTTP path a named server's route is (or will
+// be) mounted at under baseURL, always with a trailing slash so it matches
+// as a subtree.
+func routeForServer(baseURL *url.URL, name string) string {
+	mcpRoute := path.Join(baseURL.Path, name)
+	if !strings.HasPrefix(mcpRoute, "/") {
+		mcpRoute = "/" + mcpRoute
+	}
+	if !strings.HasSuffix(mcpRoute, "/") {
+		mcpRoute += "/"
+	}
+	return mcpRoute
+}
+
+// notReadyHandler responds to every request with a clear, immediate error
+// instead of a bare 404, for a server with no working connection right now
+// (most commonly: no valid OAuth token yet - see err, which for that case
+// already carries the exact `-authorize` command to run, courtesy of
+// oauthAwareError).
+func notReadyHandler(name string, err error) http.Handler {
+	message := fmt.Sprintf("mcp-proxy: server %q is not available: %v\n", name, err)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, message, http.StatusServiceUnavailable)
+	})
+}
+
+// wrapHandler applies a server's configured middlewares (panic recovery,
+// request logging, per-server bearer tokens) around its proxying handler.
+func wrapHandler(name string, clientConfig *MCPClientConfigV2, srv *Server) http.Handler {
+	middlewares := make([]MiddlewareFunc, 0)
+	middlewares = append(middlewares, recoverMiddleware(name))
+	if clientConfig.Options.LogEnabled.OrElse(false) {
+		middlewares = append(middlewares, loggerMiddleware(name))
+	}
+	if len(clientConfig.Options.AuthTokens) > 0 {
+		middlewares = append(middlewares, newAuthMiddleware(clientConfig.Options.AuthTokens))
+	}
+	return chainMiddleware(srv.handler, middlewares...)
+}
+
+// serverRoute is the handler mounted for a server that didn't successfully
+// connect at startup. It implements the retry design in
+// docs/OAUTH_LIFECYCLE.md: every request against it first does a purely
+// local, no-network check (the same one -auth-status performs, via
+// checkServerAuth) - if there's plausibly no usable credential yet, it
+// fails immediately with no connection attempt, so retrying on every
+// request to a still-unauthorized server costs nothing and leaks nothing.
+// If a credential now looks present, it attempts a real connect, with
+// concurrent requests coalesced through sf into a single attempt. On
+// success it becomes a plain pass-through to the now-working handler, and
+// this machinery is never consulted again for this server - route mounting
+// happens exactly once, at startup; only the internal ready/not-ready state
+// changes afterward.
+type serverRoute struct {
+	name         string
+	clientConfig *MCPClientConfigV2
+	proxyConfig  *MCPProxyConfigV2
+	info         mcp.Implementation
+	ctx          context.Context
+
+	sf singleflight.Group
+
+	mu     sync.RWMutex
+	client *Client      // nil until a connect attempt succeeds
+	ready  http.Handler // nil until a connect attempt succeeds
+}
+
+func newServerRoute(ctx context.Context, name string, clientConfig *MCPClientConfigV2, proxyConfig *MCPProxyConfigV2, info mcp.Implementation) *serverRoute {
+	return &serverRoute{
+		name:         name,
+		clientConfig: clientConfig,
+		proxyConfig:  proxyConfig,
+		info:         info,
+		ctx:          ctx,
+	}
+}
+
+func (r *serverRoute) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	r.mu.RLock()
+	ready := r.ready
+	r.mu.RUnlock()
+	if ready != nil {
+		ready.ServeHTTP(w, req)
+		return
+	}
+
+	if auth := checkServerAuth(r.name, r.clientConfig); !auth.ok {
+		notReadyHandler(r.name, errors.New(auth.status)).ServeHTTP(w, req)
+		return
+	}
+
+	v, err, _ := r.sf.Do("connect", r.connect)
+	if err != nil {
+		notReadyHandler(r.name, err).ServeHTTP(w, req)
+		return
+	}
+	v.(http.Handler).ServeHTTP(w, req)
+}
+
+// connect builds a fresh client and attempts to connect and initialize it.
+// singleflight guarantees at most one call runs at a time per route:
+// concurrent requests that find a connect already in progress wait for its
+// result instead of each starting their own. On success the result is
+// cached in r.ready and this is never called again for this route; on
+// failure, the half-built client is closed here so a broken server being
+// retried on every request doesn't leak a connection per attempt.
+func (r *serverRoute) connect() (any, error) {
+	r.mu.RLock()
+	if r.ready != nil {
+		h := r.ready
+		r.mu.RUnlock()
+		return h, nil
+	}
+	r.mu.RUnlock()
+
+	mcpClient, err := newMCPClient(r.name, r.clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	srv, err := newMCPServer(r.name, r.proxyConfig, r.clientConfig)
+	if err != nil {
+		_ = mcpClient.Close()
+		return nil, err
+	}
+	slog.Info("Connecting (retry)", "client", r.name)
+	if err := mcpClient.addToMCPServer(r.ctx, r.info, srv.mcpServer); err != nil {
+		slog.Error("Retry failed to add client to server", "client", r.name, "err", err)
+		_ = mcpClient.Close()
+		return nil, err
+	}
+	slog.Info("Connected (retry)", "client", r.name)
+
+	handler := wrapHandler(r.name, r.clientConfig, srv)
+	r.mu.Lock()
+	r.client = mcpClient
+	r.ready = handler
+	r.mu.Unlock()
+	return handler, nil
+}
+
+// Close closes the underlying client if this route ever successfully
+// connected; a no-op otherwise. Safe to call concurrently with an
+// in-flight connect: the daemon shutdown path (http.go) cancels ctx before
+// calling this, so an attempt racing shutdown will normally fail on the
+// now-canceled context rather than land a client this never closes -
+// see docs/OAUTH_LIFECYCLE.md.
+func (r *serverRoute) Close() error {
+	r.mu.RLock()
+	c := r.client
+	r.mu.RUnlock()
+	if c == nil {
+		return nil
+	}
+	return c.Close()
+}


### PR DESCRIPTION
Draft PR covering the full proposed series described in [`docs/OAUTH_LIFECYCLE.md`](https://github.com/timcharper/mcp-proxy/blob/oauth-lifecycle/docs/OAUTH_LIFECYCLE.md): closing the gap where a downstream server that isn't OAuth-authorized yet at startup never gets its route mounted, requiring a full daemon restart after running `-authorize`.

This is a **stack of 4 commits**, each independently buildable/testable, intended to land as **separate PRs one at a time** rather than as one big change:

1. `docs: add OAuth/route lifecycle design notes, add AGENTS.md` — the design doc this series implements, plus a repo `AGENTS.md`.
2. `refactor: extract per-server connect/mount into connectAndMount` — no behavior change, groundwork for calling connect logic more than once.
3. `feat: always mount a server's route, fail fast instead of 404` — every configured server's route is mounted at startup; a server with no valid credential yet responds `503` (with the exact `-authorize` command to run) instead of a bare 404.
4. `feat: lazy connect-on-request for not-yet-ready routes, no restart` — a not-yet-ready route retries the connection lazily on the next request (coalesced per-server via `singleflight`, so concurrent requests share one attempt), so running `-authorize` is enough — no restart, no re-mount.

I opened this as a draft to establish direction and get early feedback on the overall approach before splitting it up. #78 is the first commit of this series (the design doc) submitted on its own as a real, mergeable PR.

Design rationale, rejected alternatives (fsnotify, in-memory token cache, crash-on-change, config hot-reload), and a documented known limitation (concurrent refresh-token use isn't serialized by `mcp-go`, accepted as-is) are all written up in the doc itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)